### PR TITLE
Changed django-admin.py to manage.py, which uses your local settings.py

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -388,8 +388,8 @@ are a couple key differences:
 
 Let's test it out:
 
-1. Start up the consumer using the management command: ``django-admin.py run_huey``
-2. Open up a shell: ``django-admin.py shell``
+1. Start up the consumer using the management command: ``./manage.py run_huey``
+2. Open up a shell: ``manage.py shell``
 3. Try running the ``count_beans()`` function a couple times
 
 .. image:: example_django.jpg


### PR DESCRIPTION
Changed django-admin.py to manage.py, which uses your local settings.py file and works without you having to set environment variables
