### PR TITLE
Bad test in `CommandSchedule.load` ?

### DIFF
--- a/huey/queue.py
+++ b/huey/queue.py
@@ -130,7 +130,7 @@ class CommandSchedule(object):
         if self.task_store:
             serialized = self.task_store.get(self.key_name)
             
-            if serialized:
+            if serialized is not EmptyData:
                 self.load_commands(pickle.loads(serialized))
     
     def load_commands(self, messages):


### PR DESCRIPTION
I sometimes have, at the huey consumer initialisation time

<pre>
ERROR 2012-11-14 12:16:39,752 huey.consumer.logger error
Traceback (most recent call last):
  File "/home/www/venv/lib/python2.6/site-packages/huey/bin/huey_consumer.py", line 251, in run
    self.start()
  File "/home/www/venv/lib/python2.6/site-packages/huey/bin/huey_consumer.py", line 208, in start
    self.load_schedule()
  File "/home/www/venv/lib/python2.6/site-packages/huey/bin/huey_consumer.py", line 232, in load_schedule
    self.schedule.load()
  File "/home/www/venv/lib/python2.6/site-packages/huey/queue.py", line 133, in load
    self.load_commands(pickle.loads(serialized))
  File "/usr/lib/python2.6/pickle.py", line 1373, in loads
    file = StringIO(str)
TypeError: expected read buffer, type found
INFO 2012-11-14 12:16:39,769 huey.consumer.logger saving command schedule
INFO 2012-11-14 12:16:39,769 huey.consumer.logger shutdown...
</pre>


This commit seems to fix the issue.
Regards
