### PR TITLE
Fix for TypeError: can't compare datetime to bool

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -266,7 +266,10 @@ class Huey(object):
             if not peek:
                 self.restore(task)
             return True
-        return revoke_until is None or revoke_until > dt
+        if revoke_until and dt:
+            return revoke_until > dt
+        else:
+            return True
 
     def add_schedule(self, task):
         msg = registry.get_message_for_task(task)


### PR DESCRIPTION
I repeatedly got `TypeError: can't compare datetime.datetime to bool` for this line. The consumer needed to be restarted for each exception, making Huey unusable. If a number of such tasks were queued, the same number of consumer restarts were required.

Not entirely sure whether `revoke_until` or `dt` was the bool in this case, but this should logically be a safe fix.
