### PR TITLE
Allow to specify task_id

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -83,7 +83,7 @@ class Huey(object):
             klass = create_task(QueueTask, func, retries_as_argument, name)
 
             def schedule(args=None, kwargs=None, eta=None, delay=None,
-                         convert_utc=True):
+                         convert_utc=True, task_id=None):
                 if delay and eta:
                     raise ValueError('Both a delay and an eta cannot be '
                                      'specified at the same time')
@@ -96,7 +96,8 @@ class Huey(object):
                     (args or (), kwargs or {}),
                     execute_time=eta,
                     retries=retries,
-                    retry_delay=retry_delay)
+                    retry_delay=retry_delay,
+                    task_id=task_id)
                 return self.enqueue(cmd)
 
             func.schedule = schedule

--- a/huey/tests/queue.py
+++ b/huey/tests/queue.py
@@ -306,10 +306,15 @@ class HueyTestCase(unittest.TestCase):
         add2('k3', 'v3')
         task3 = res_huey.dequeue()
 
+        add2.schedule(args=('k4', 'v4'), task_id='test_task_id')
+        task4 = res_huey.dequeue()
+
         # sanity check what should be run
         self.assertTrue(res_huey.ready_to_run(task1))
         self.assertFalse(res_huey.ready_to_run(task2))
         self.assertTrue(res_huey.ready_to_run(task3))
+        self.assertTrue(res_huey.ready_to_run(task4))
+        self.assertEqual('test_task_id', task4.task_id)
 
     def test_task_delay(self):
         curr = datetime.datetime.utcnow()


### PR DESCRIPTION
Here is small addition allows to specify tsak_id before actual schedule call.

This is helpful when you like to make the code more robust and save scheduled task id before anything can be broken.

Also this feature exists in celery api, so it is not worse to add it to huey.
