### PR TITLE
Update load_class() to import modules locally

### DIFF
--- a/huey/utils.py
+++ b/huey/utils.py
@@ -1,13 +1,16 @@
-import datetime
+import os
 import sys
 import time
-
+import datetime
 
 class EmptyData(object):
     pass
 
 
 def load_class(s):
+    ldir = os.getcwd()
+    if ldir not in sys.path:
+        sys.path.insert(0, ldir)
     path, klass = s.rsplit('.', 1)
     __import__(path)
     mod = sys.modules[path]


### PR DESCRIPTION
With testing, the consumer doesn't properly import modules relative to where you're executing `huey_consumer.py`, instead it tries to import them relative to the location that this `utils.py` file is located.

Adding the `cwd` to `sys.path` allows `huey_consumer.py` to correctly import the module and get the `huey` class after it is initialized.