### PR TITLE
Make redis_backend.py reconnect on database failure

### DIFF
--- a/huey/backends/redis_backend.py
+++ b/huey/backends/redis_backend.py
@@ -10,10 +10,17 @@ from huey.backends.base import BaseQueue
 from huey.backends.base import BaseSchedule
 from huey.utils import EmptyData
 
-
 def clean_name(name):
     return re.sub('[^a-z0-9]', '', name)
 
+
+def loop_conn(self):
+    try:
+        self.conn.ping()
+    except:
+        self.conn = redis.Redis(**self.queue_conn)
+    return self.conn
+    
 
 class RedisQueue(BaseQueue):
     """
@@ -30,22 +37,23 @@ class RedisQueue(BaseQueue):
         super(RedisQueue, self).__init__(name, **connection)
 
         self.queue_name = 'huey.redis.%s' % clean_name(name)
-        self.conn = redis.Redis(**connection)
+        self.queue_conn = connection
+        self.loop_conn = loop_conn
 
     def write(self, data):
-        self.conn.lpush(self.queue_name, data)
+        self.loop_conn(self).lpush(self.queue_name, data)
 
     def read(self):
-        return self.conn.rpop(self.queue_name)
+        return self.loop_conn(self).rpop(self.queue_name)
 
     def remove(self, data):
-        return self.conn.lrem(self.queue_name, data)
+        return self.loop_conn(self).lrem(self.queue_name, data)
 
     def flush(self):
-        self.conn.delete(self.queue_name)
+        self.loop_conn(self).delete(self.queue_name)
 
     def __len__(self):
-        return self.conn.llen(self.queue_name)
+        return self.loop_conn(self).llen(self.queue_name)
 
 
 class RedisBlockingQueue(RedisQueue):
@@ -58,7 +66,7 @@ class RedisBlockingQueue(RedisQueue):
 
     def read(self):
         try:
-            return self.conn.brpop(self.queue_name)[1]
+            return self.loop_conn(self).brpop(self.queue_name)[1]
         except ConnectionError:
             # unfortunately, there is no way to differentiate a socket timing
             # out and a host being unreachable
@@ -70,23 +78,24 @@ class RedisSchedule(BaseSchedule):
         super(RedisSchedule, self).__init__(name, **connection)
 
         self.key = 'huey.schedule.%s' % clean_name(name)
-        self.conn = redis.Redis(**connection)
+        self.queue_conn = connection
+        self.loop_conn = loop_conn
 
     def convert_ts(self, ts):
         return time.mktime(ts.timetuple())
 
     def add(self, data, ts):
-        self.conn.zadd(self.key, data, self.convert_ts(ts))
+        self.loop_conn(self).zadd(self.key, data, self.convert_ts(ts))
 
     def read(self, ts):
         unix_ts = self.convert_ts(ts)
-        tasks = self.conn.zrangebyscore(self.key, 0, unix_ts)
+        tasks = self.loop_conn(self).zrangebyscore(self.key, 0, unix_ts)
         if len(tasks):
-            self.conn.zremrangebyscore(self.key, 0, unix_ts)
+            self.loop_conn(self).zremrangebyscore(self.key, 0, unix_ts)
         return tasks
 
     def flush(self):
-        self.conn.delete(self.key)
+        self.loop_conn(self).delete(self.key)
 
 
 class RedisDataStore(BaseDataStore):
@@ -94,33 +103,35 @@ class RedisDataStore(BaseDataStore):
         super(RedisDataStore, self).__init__(name, **connection)
 
         self.storage_name = 'huey.results.%s' % clean_name(name)
-        self.conn = redis.Redis(**connection)
+        self.queue_conn = connection
+        self.loop_conn = loop_conn
 
     def put(self, key, value):
-        self.conn.hset(self.storage_name, key, value)
+        self.loop_conn(self).hset(self.storage_name, key, value)
 
     def peek(self, key):
-        if self.conn.hexists(self.storage_name, key):
-            return self.conn.hget(self.storage_name, key)
+        if self.loop_conn(self).hexists(self.storage_name, key):
+            return self.loop_conn(self).hget(self.storage_name, key)
         return EmptyData
 
     def get(self, key):
         val = self.peek(key)
         if val is not EmptyData:
-            self.conn.hdel(self.storage_name, key)
+            self.loop_conn(self).hdel(self.storage_name, key)
         return val
 
     def flush(self):
-        self.conn.delete(self.storage_name)
+        self.loop_conn(self).delete(self.storage_name)
 
 
 class RedisEventEmitter(BaseEventEmitter):
     def __init__(self, channel, **connection):
         super(RedisEventEmitter, self).__init__(channel, **connection)
-        self.conn = redis.Redis(**connection)
+        self.queue_conn = connection
+        self.loop_conn = loop_conn
 
     def emit(self, message):
-        self.conn.publish(self.channel, message)
+        self.loop_conn(self).publish(self.channel, message)
 
 
 Components = (RedisBlockingQueue, RedisDataStore, RedisSchedule,


### PR DESCRIPTION
Currently if the connection to the database is lost, for any reason... Huey doesn't exit or reconnect to the database. It simply hangs.  
This change, while perhaps not the worlds best way to do it allows Huey to attempt to reconnect to the database should anything happen  

This includes socket timeout, database restart, network failure. All cases where connection is lost, Huey will attempt to reconnect.   
This change still allows for different database configurations for each class, and still attempts to only have a single active connection per class.

Let me know if you have a problem with it and I can attempt to do it another way.