### PR TITLE
Work/self aware tasks

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -6,7 +6,6 @@ import time
 import traceback
 import uuid
 from functools import wraps
-from inspect import getargspec
 from huey.backends.dummy import DummySchedule
 from huey.exceptions import DataStoreGetException
 from huey.exceptions import DataStorePutException
@@ -414,7 +413,6 @@ def create_task(task_class, func, retries_as_argument=False, task_name=None, inc
         args, kwargs = self.data or ((), {})
         if retries_as_argument:
             kwargs['retries'] = self.retries
-        funargs, _, _, _ = getargspec(func)
         if include_task:
             kwargs['task'] = self
         return func(*args, **kwargs)

--- a/huey/api.py
+++ b/huey/api.py
@@ -73,13 +73,13 @@ class Huey(object):
         self.store_none = store_none
         self.always_eager = always_eager
 
-    def task(self, retries=0, retry_delay=0, retries_as_argument=False,
+    def task(self, retries=0, retry_delay=0, retries_as_argument=False, include_task=False,
              name=None):
         def decorator(func):
             """
             Decorator to execute a function out-of-band via the consumer.
             """
-            klass = create_task(QueueTask, func, retries_as_argument, name)
+            klass = create_task(QueueTask, func, retries_as_argument, name, include_task)
 
             def schedule(args=None, kwargs=None, eta=None, delay=None,
                          convert_utc=True, task_id=None):
@@ -408,15 +408,15 @@ class PeriodicQueueTask(QueueTask):
         return False
 
 
-def create_task(task_class, func, retries_as_argument=False, task_name=None,
+def create_task(task_class, func, retries_as_argument=False, task_name=None, include_task=False,
                 **kwargs):
     def execute(self):
         args, kwargs = self.data or ((), {})
         if retries_as_argument:
             kwargs['retries'] = self.retries
         funargs, _, _, _ = getargspec(func)
-        if 'self' in funargs:
-            kwargs['self'] = self
+        if include_task:
+            kwargs['task'] = self
         return func(*args, **kwargs)
 
     attrs = {

--- a/huey/api.py
+++ b/huey/api.py
@@ -6,7 +6,7 @@ import time
 import traceback
 import uuid
 from functools import wraps
-
+from inspect import getargspec
 from huey.backends.dummy import DummySchedule
 from huey.exceptions import DataStoreGetException
 from huey.exceptions import DataStorePutException
@@ -45,7 +45,6 @@ class Huey(object):
 
         from huey.api import Huey, crontab
         from huey.backends.redis_backend import RedisQueue, RedisDataStore, RedisSchedule
-
         queue = RedisQueue('my-app')
         result_store = RedisDataStore('my-app')
         schedule = RedisSchedule('my-app')
@@ -415,6 +414,9 @@ def create_task(task_class, func, retries_as_argument=False, task_name=None,
         args, kwargs = self.data or ((), {})
         if retries_as_argument:
             kwargs['retries'] = self.retries
+        funargs, _, _, _ = getargspec(func)
+        if 'self' in funargs:
+            kwargs['self'] = self.task
         return func(*args, **kwargs)
 
     attrs = {

--- a/huey/api.py
+++ b/huey/api.py
@@ -416,7 +416,7 @@ def create_task(task_class, func, retries_as_argument=False, task_name=None,
             kwargs['retries'] = self.retries
         funargs, _, _, _ = getargspec(func)
         if 'self' in funargs:
-            kwargs['self'] = self.task
+            kwargs['self'] = self
         return func(*args, **kwargs)
 
     attrs = {

--- a/huey/tests/queue.py
+++ b/huey/tests/queue.py
@@ -27,11 +27,16 @@ res_huey_nones = Huey(res_queue, res_store, store_none=True)
 
 # store some global state
 state = {}
+last_executed_task_class = []
 
 # create a decorated queue command
 @huey.task()
 def add(key, value):
     state[key] = value
+
+@huey.task()
+def self_aware(key, value, self=None):
+    last_executed_task_class.append(self.__class__.__name__)
 
 # create a periodic queue command
 @huey.periodic_task(crontab(minute='0'))
@@ -72,10 +77,12 @@ def returns_none2():
 class HueyTestCase(unittest.TestCase):
     def setUp(self):
         global state
+        global last_executed_task_class
         queue.flush()
         res_queue.flush()
         schedule.flush()
         state = {}
+        last_executed_task_class = []
 
     def test_registration(self):
         self.assertTrue('queuecmd_add' in registry)
@@ -227,6 +234,21 @@ class HueyTestCase(unittest.TestCase):
         self.assertEqual(state['k'], 'X')
 
         self.assertRaises(TypeError, huey.execute, huey.dequeue())
+
+    def test_self_awareness(self):
+        self_aware('k', 'v')
+        task = huey.dequeue()
+        huey.execute(task)
+        self.assertEqual(last_executed_task_class.pop(), "queuecmd_self_aware")
+
+        self_aware('k', 'v')
+        huey.execute(huey.dequeue())
+        self.assertEqual(last_executed_task_class.pop(), "queuecmd_self_aware")
+
+        add('k', 'x')
+        huey.execute(huey.dequeue())
+        self.assertEqual(len(last_executed_task_class), 0)
+
 
     def test_revoke(self):
         ac = AddTask(('k', 'v'))

--- a/huey/tests/queue.py
+++ b/huey/tests/queue.py
@@ -34,9 +34,9 @@ last_executed_task_class = []
 def add(key, value):
     state[key] = value
 
-@huey.task()
-def self_aware(key, value, self=None):
-    last_executed_task_class.append(self.__class__.__name__)
+@huey.task(include_task=True)
+def self_aware(key, value, task=None):
+    last_executed_task_class.append(task.__class__.__name__)
 
 # create a periodic queue command
 @huey.periodic_task(crontab(minute='0'))


### PR DESCRIPTION
This is a patch for issue https://github.com/coleifer/huey/issues/93.
Works the following way:
if the function has a self parameter, the task instance is passed to it, so we can do pretty fancy stuff inside the executed task. For example report progess to the pubsub 
```
@long_running_huey.task()
def run_long(a,b,c,self):
    for i in range(1, 100):
        progress  = {"progress": i}
        long_running_huey.emit_task(progress, self)
        sleep(1)
```