### PR TITLE
Crontab seconds support

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -444,7 +444,8 @@ def create_task(task_class, func, retries_as_argument=False, task_name=None,
 dash_re = re.compile('(\d+)-(\d+)')
 every_re = re.compile('\*\/(\d+)')
 
-def crontab(month='*', day='*', day_of_week='*', hour='*', minute='*'):
+def crontab(month='*', day='*', day_of_week='*', hour='*', minute='*',
+            second='0'):
     """
     Convert a "crontab"-style set of parameters into a test function that will
     return True when the given datetime matches the parameters set forth in
@@ -461,7 +462,8 @@ def crontab(month='*', day='*', day_of_week='*', hour='*', minute='*'):
         ('d', day, range(1, 32)),
         ('w', day_of_week, range(7)),
         ('H', hour, range(24)),
-        ('M', minute, range(60))
+        ('M', minute, range(60)),
+        ('S', second, range(60))
     )
     cron_settings = []
 
@@ -499,12 +501,12 @@ def crontab(month='*', day='*', day_of_week='*', hour='*', minute='*'):
         cron_settings.append(sorted(list(settings)))
 
     def validate_date(dt):
-        _, m, d, H, M, _, w, _, _ = dt.timetuple()
+        _, m, d, H, M, S, w, _, _ = dt.timetuple()
 
         # fix the weekday to be sunday=0
         w = (w + 1) % 7
 
-        for (date_piece, selection) in zip([m, d, w, H, M], cron_settings):
+        for (date_piece, selection) in zip([m, d, w, H, M, S], cron_settings):
             if date_piece not in selection:
                 return False
 

--- a/huey/tests/crontab.py
+++ b/huey/tests/crontab.py
@@ -45,6 +45,15 @@ class CrontabTestCase(unittest.TestCase):
             res = validate_m(datetime.datetime(2011, 1, 1, 1, x))
             self.assertEqual(res, x in valids)
 
+    def test_crontab_seconds(self):
+        # validates the following seconds
+        valids = [0, 1, 4, 6, 8, 9, 12, 18, 24, 30, 36, 42, 48, 54]
+        validate_m = crontab(second='4,8-9,*/6,1')
+
+        for x in range(60):
+            res = validate_m(datetime.datetime(2011, 1, 1, 1, 1, x))
+            self.assertEqual(res, x in valids)
+
     def test_crontab_day_of_week(self):
         # validates the following days of week
         # jan, 1, 2011 is a saturday


### PR DESCRIPTION
Hi  - I had a need to run a task every few seconds and have tweaked crontab to support a 'second' argument - being a nice lightweight thread-based implementation I don't see why we can't do a bit more than cron, as long as people use it responsibly. I defaulted the argument to 0 instead of * so that the existing behaviour remains cron-like. Even if people don't use the seconds argument this also fixes the edge case where someone chooses a periodic_task_interval < 60 in settings.py. I copied the test_crontab_minute case to test the seconds argument.