### PR TITLE
Django 1.8 warning: Use importlib instead of django.db.models.loading

### DIFF
--- a/huey/djhuey/management/commands/run_huey.py
+++ b/huey/djhuey/management/commands/run_huey.py
@@ -4,7 +4,10 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 try:
     from django.apps import apps as django_apps


### PR DESCRIPTION
Removes this warning in django 1.8:

```
RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated
in favor of the new application loading system.
```