### PR TITLE
self.conn.brpop returns None on timeout

### DIFF
--- a/huey/backends/redis_backend.py
+++ b/huey/backends/redis_backend.py
@@ -72,7 +72,7 @@ class RedisBlockingQueue(RedisQueue):
             return self.conn.brpop(
                 self.queue_name,
                 timeout=self.read_timeout)[1]
-        except ConnectionError:
+        except (ConnectionError, TypeError, IndexError):
             # unfortunately, there is no way to differentiate a socket timing
             # out and a host being unreachable
             return None


### PR DESCRIPTION
I referenced this issue here:

https://github.com/coleifer/huey/commit/ddbe0fe1dc3d9d7a62d923761188893102b4a109#diff-9e3f0f0b848bdc74ba136684fb07ddfcR74

Here's the fix.