### PR TITLE
Change how heuy_consumer is started

### DIFF
--- a/huey/bin/huey_consumer.py
+++ b/huey/bin/huey_consumer.py
@@ -91,7 +91,7 @@ def load_huey(path):
         raise
 
 
-if __name__ == '__main__':
+def consumer_main():
     parser = get_option_parser()
     options, args = parser.parse_args()
 
@@ -115,3 +115,7 @@ if __name__ == '__main__':
         options.scheduler_interval,
         options.periodic_task_interval)
     consumer.run()
+
+
+if __name__ == '__main__':
+    consumer_main()

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
         'console_scripts': [
             'huey_consumer = huey.bin.huey_consumer:consumer_main'
             ]
-        }
+    }
+    scripts = ['huey/bin/huey_consumer.py'],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,9 @@ setup(
         'Framework :: Django',
     ],
     test_suite='runtests.runtests',
-    scripts = ['huey/bin/huey_consumer.py'],
+    entry_points={
+        'console_scripts': [
+            'huey_consumer = huey.bin.huey_consumer:consumer_main'
+            ]
+        }
 )


### PR DESCRIPTION
 This fixes #116

 The logic behind this is that other programs that would like to
 reuse huey can now do:

      from huey.bin.huey_consumer import consumer_main

 and thus include consumer main as a sub command.

 Also, setuptools takes care of properly instaling scripts in windows
 and virtual environments.