### PR TITLE
allow to specify main redis conenction params in url form

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -37,6 +37,8 @@ Using redis
         'backend': 'huey.backends.redis_backend',  # required.
         'name': 'unique name',
         'connection': {'host': 'localhost', 'port': 6379},
+        # or by url:
+        # 'connection': {'url': 'redis://localhost/1'}
         'always_eager': False, # Defaults to False when running via manage.py run_huey
 
         # Options to pass into the consumer when running ``manage.py run_huey``


### PR DESCRIPTION
when specifying hostnames via environment vars it's nice to be able to configure the connection via a single url var rather than separate host, port, db parameters

redis-py supports this (analogous to https://github.com/kennethreitz/dj-database-url)

just a small change to support it in Huey too