### PR TITLE
Add python 3.4 and python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 services:
   - redis
   - rabbitmq


### PR DESCRIPTION
Huey tests still fail :(

![image](https://cloud.githubusercontent.com/assets/128286/11677712/280e7ac4-9e41-11e5-8b01-508c9093e2c6.png)

But 3.4 and 3.5 should be in there :)