### PR TITLE
fix examples/simple support for python 3.x

### DIFF
--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -1,6 +1,6 @@
 import os
 if os.environ.get('WORKER_CLASS') in ('greenlet', 'gevent'):
-    print 'Monkey-patching for gevent.'
+    print('Monkey-patching for gevent.')
     from gevent import monkey; monkey.patch_all()
 
 from config import huey
@@ -8,6 +8,8 @@ from tasks import count_beans
 
 
 if __name__ == '__main__':
-    beans = raw_input('How many beans? ')
+    try: input = raw_input
+    except NameError: pass
+    beans = input('How many beans? ')
     count_beans(int(beans))
     print('Enqueued job to count %s beans' % beans)

--- a/examples/simple/tasks.py
+++ b/examples/simple/tasks.py
@@ -16,7 +16,7 @@ def every_five_mins():
 
 @huey.task(retries=3, retry_delay=10)
 def try_thrice(msg):
-    print '----TRY THRICE: %s----' % msg
+    print('----TRY THRICE: %s----' % msg)
     if random.randint(1, 3) == 1:
         print('OK')
     else:


### PR DESCRIPTION
```
print '...'  ->  print('...')
```
and raw_input() was renamed to input() in Python 3.x

```
# Fix Python 2.x.
try: input = raw_input
except NameError: pass
```