### PR TITLE
Upgrade django command for django 1.8.

### DIFF
--- a/huey/bin/huey_consumer.py
+++ b/huey/bin/huey_consumer.py
@@ -4,7 +4,7 @@ import logging
 import optparse
 import os
 import sys
-from logging.handlers import FileHandler
+from logging import FileHandler
 
 from huey.consumer import Consumer
 from huey.utils import load_class


### PR DESCRIPTION
Django 1.8 argument parsing is based on argparse rather than optparse.

Commands that use optparse still work, but django prints deprecation warnings when you use optparse-style arguments.

This patch updates the run_huey command to use argparse.
On django < 1.8 it falls back to optparse.