### PR TITLE
Fix issue #157

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -59,11 +59,20 @@ class BaseProcess(object):
         return time.mktime(self.get_now().timetuple())
 
     def sleep_for_interval(self, start_ts, nseconds):
-        delta = time.time() - start_ts
-        if delta < nseconds:
-            seconds = nseconds - (time.time() - start_ts)
-            self._logger.debug('Sleeping for %s' % seconds)
+        sleep_time = nseconds - (time.time() - start_ts)
+        if sleep_time <= 0:
+            return
+        self._logger.debug('Sleeping for %s' % sleep_time)
+        try:
+            # Calculate sleep time inline to try to
+            # improve accuracy and not sleep if the
+            # kernel preempted us during logging
             time.sleep(nseconds - (time.time() - start_ts))
+        except IOError:
+            # Time moved forward and we provided
+            # a negative value to time.sleep()
+            self._logger.debug('Aborted sleeping '
+                               'as time moved forward')
 
     def enqueue(self, task):
         try:


### PR DESCRIPTION
Catch IOError when calling time.sleep() to recover from races
where our process may get preempted and not given CPU back until
the sleep deadline has already passed.