### PR TITLE
Support configuration using a single Redis URL

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -50,6 +50,16 @@ Using redis on a network host with 16 worker greenlets.
         'consumer': {'workers': 16, 'worker_type': 'greenlet'},
     }
 
+It is also possible to specify the connection using a Redis URL, making it easy to configure this
+setting using a single environment variable:
+
+.. code-block:: python
+
+    HUEY = {
+        'name': 'my-app',
+        'url': os.environ.get('REDIS_URL', 'redis://localhost:6379/?db=1')
+    }
+
 Alternatively, you can just assign a :py:class:`Huey` instance to the ``HUEY`` setting:
 
 .. code-block:: python

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -104,9 +104,18 @@ end"""
 
 
 class RedisStorage(BaseStorage):
-    def __init__(self, name='huey', blocking=False, read_timeout=1,
-                 max_errors=1000, connection_pool=None, **connection_params):
-        if connection_pool is None:
+    def __init__(self, name='huey', blocking=False, read_timeout=1, max_errors=1000,
+            connection_pool=None, url=None, **connection_params):
+        if len([x for x in (url, connection_pool, connection_params) if x]) > 1:
+            raise ValueError(
+                'The connection configuration is over-determined. '
+                'Please specify only one of the the following: '
+                '"url", "connection_pool", or "connection_params"'
+            )
+
+        if url:
+            connection_pool = redis.ConnectionPool.from_url(url, decode_components=True)
+        elif connection_pool is None:
             connection_pool = redis.ConnectionPool(**connection_params)
 
         self.pool = connection_pool


### PR DESCRIPTION
This little PR adds support for specifying Redis connection details using a single URL, e.g. in combination with Django:

```python
HUEY = {
    'url': 'redis://localhost:6379/?db=1'
}
```

People wanting to implement [12factor configuration using envvars](https://12factor.net/config) will find this useful (at least I hope so).

The supported URL schemes are defined by redis-py and described in https://github.com/andymccurdy/redis-py/blob/master/redis/connection.py#L777.