### PR TITLE
Fix handling of negative sleep times.

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -70,16 +70,11 @@ class BaseProcess(object):
         if sleep_time <= 0:
             return
         self._logger.debug('Sleeping for %s' % sleep_time)
-        try:
-            # Calculate sleep time inline to try to
-            # improve accuracy and not sleep if the
-            # kernel preempted us during logging
-            time.sleep(nseconds - (time.time() - start_ts))
-        except IOError:
-            # Time moved forward and we provided
-            # a negative value to time.sleep()
-            self._logger.debug('Aborted sleeping '
-                               'as time moved forward')
+        # Recompute time to sleep to improve accuracy in case the process was
+        # pre-empted by the kernel while logging.
+        sleep_time = nseconds - (time.time() - start_ts)
+        if sleep_time > 0:
+            time.sleep(sleep_time)
 
     def enqueue(self, task):
         try:


### PR DESCRIPTION
In Python 2, calling `time.sleep()` with a negative argument has platform-dependent results.  On Linux, it will throw an IOError, which is the only case the code handles correctly.  On other platforms, it results in sleeping for an infinite time, or undefined behaviour.  In Python 3, `time.sleep()` will throw a ValueError when called with a negative argument.  See https://bugs.python.org/issue12459 for additional information.

The easiest way to solve this problem for all Python versions is to compute the time to sleep beforehand and only call `time.sleep()` if the argument is postitive.  (This isn't in any way slower or less accurate than the previous solution, as the comment I removed in this patch suggests.  CPython local
variables are accessed by static index rather than by name, and are thus just as fast as the execution frame stack used to store temporaries in expressions.)