### PR TITLE
Feature/utc fixes

### DIFF
--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -133,13 +133,12 @@ their default values.
     every second, but you can increase the interval to as much as 60 seconds.
 
 ``-u``, ``--utc``
-    Indicates that the consumer should use UTC time for all tasks, crontabs
-    and scheduling.  Default is True, so it is not actually necessary to use
-    this option.
+    Indicates that the consumer should use UTC time for crontabs.
+    Default is True, so it is not actually necessary to use this option.
 
-``--localtime``
-    Indicates that the consumer should use localtime for all tasks. The default
-    behavior is to use UTC everywhere.
+``-o``, ``--localtime``
+    Indicates that the consumer should use localtime for crontabs.
+    The default behavior is to use UTC everywhere.
 
 Examples
 ^^^^^^^^

--- a/huey/api.py
+++ b/huey/api.py
@@ -18,7 +18,7 @@ from huey.exceptions import QueueWriteException
 from huey.exceptions import ScheduleAddException
 from huey.exceptions import ScheduleReadException
 from huey.registry import registry
-from huey.utils import local_to_utc
+from huey.utils import local_to_utc, is_naive, aware_to_utc, make_naive, is_aware
 from huey.utils import wrap_exception
 
 
@@ -94,8 +94,13 @@ class Huey(object):
                 if delay:
                     eta = (datetime.datetime.now() +
                            datetime.timedelta(seconds=delay))
-                if convert_utc and eta:
-                    eta = local_to_utc(eta)
+                if eta:
+                    if is_naive(eta) and convert_utc:
+                        eta = local_to_utc(eta)
+                    elif is_aware(eta) and convert_utc:
+                        eta = aware_to_utc(eta)
+                    elif is_aware(eta) and not convert_utc:
+                        eta = make_naive(eta)
                 cmd = klass(
                     (args or (), kwargs or {}),
                     execute_time=eta,

--- a/huey/utils.py
+++ b/huey/utils.py
@@ -3,6 +3,40 @@ import sys
 import time
 
 
+class UTC(datetime.tzinfo):
+    """
+    UTC implementation taken from Python's docs.
+    Used only when pytz isn't available.
+    """
+
+    def __repr__(self):
+        return "<UTC>"
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+def is_naive(dt):
+    """
+    Determines if a given datetime.datetime is naive.
+    The concept is defined in Python's docs:
+    http://docs.python.org/library/datetime.html#datetime.tzinfo
+    Assuming value.tzinfo is either None or a proper datetime.tzinfo,
+    value.utcoffset() implements the appropriate logic.
+    """
+    return dt.utcoffset() is None
+
+
+def is_aware(dt):
+    return not is_naive(dt)
+
+
 def load_class(s):
     path, klass = s.rsplit('.', 1)
     __import__(path)
@@ -15,5 +49,24 @@ def wrap_exception(new_exc_class):
     raise new_exc_class('%s: %s' % (exc_class.__name__, exc))
 
 
+def make_naive(dt):
+    """
+    Makes an aware datetime.datetime naive in its time zone.
+    """
+    return dt.replace(tzinfo=None)
+
+
+def aware_to_utc(dt):
+    """
+    Converts an aware datetime.datetime in UTC time zone.
+    """
+    dt = dt.astimezone(UTC())
+    assert not is_naive(dt), 'Must be a time zone aware datetime'
+    return make_naive(dt)
+
+
 def local_to_utc(dt):
+    """
+    Converts a naive local datetime.datetime in UTC time zone.
+    """
     return datetime.datetime(*time.gmtime(time.mktime(dt.timetuple()))[:6])


### PR DESCRIPTION
This PR solves edges cases issues with timezones.

- When scheduling tasks passing ETAs as time zone aware datetime objects, the time zone is now used. Before it was considering the datetime was local.
- The scheduler / worker now only use UTC datetime internally, as it doesn't make sense to alter this behaviour. The `--localtime` or `--utc` now impacts only the periodic tasks (crontab). To use local datetimes when scheduling see first point.
