### PR TITLE
Add pip extras-require group "backends" to include sqlite and redis

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,6 +9,13 @@ huey can be installed from PyPI using `pip <http://www.pip-installer.org/en/late
 
     $ pip install huey
 
+
+If you want to enable SQLite and Redis backend automatically, use following command:
+
+.. code-block:: bash
+
+    $ pip install huey[backends]
+
 huey has no dependencies outside the standard library, but currently the only
 fully-implemented storage backend it ships with requires `redis <http://redis.io>`_.
 To use the redis backend, you will need to install the Redis python client:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 
 
+extras_require = {
+    'backends': ('peewee', "redis"),
+}
+
 setup(
     name='huey',
     version=__import__('huey').__version__,
@@ -9,6 +13,7 @@ setup(
     author_email='coleifer@gmail.com',
     url='http://github.com/coleifer/huey/',
     packages=find_packages(),
+    extras_require=extras_require,
     package_data={
         'huey': [
         ],


### PR DESCRIPTION
Hi coleifer, 

I made a small change so that we can install bakcend requires via `pip install huey[backends]`.

This command supports installing `peewee` and `redis` by single line of shell command.

I wish it helps : )

Inspired by:
https://github.com/coleifer/huey/issues/229