### PR TITLE
Corrected the HUEY settings

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -45,7 +45,7 @@ options with their default values:
 
     # settings.py
     HUEY = {
-        'name': settings.DATABASES['default']['name'],  # Use db name for huey.
+        'name': settings.DATABASES['default']['NAME'],  # Use db name for huey.
         'result_store': True,  # Store return values of tasks.
         'events': True,  # Consumer emits events allowing real-time monitoring.
         'store_none': False,  # If a task returns None, do not save to results.


### PR DESCRIPTION
The Django DATABASE default key is an uppercase 'NAME' while the one used in the HUEY documentation is lowercase.
A reference to this is in the django docs here: https://docs.djangoproject.com/en/1.11/ref/settings/#name
This has been changed to effect this error.