### PR TITLE
Allow configuration of Huey backend using django config

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -52,6 +52,7 @@ options with their default values:
         'always_eager': settings.DEBUG,  # If DEBUG=True, run synchronously.
         'store_errors': True,  # Store error info if task throws exception.
         'blocking': False,  # Poll the queue rather than do blocking pop.
+        'backend_class': 'huey.RedisHuey',  # Use path to redis huey by default,
         'connection': {
             'host': 'localhost',
             'port': 6379,


### PR DESCRIPTION
Huey looks promising for a small django project but I don't want to add a dependency on redis before I need to, so I want to use sqlite instead. I could set HUEY to an instance of `SqliteHuey`, but then I can't configure the consumers in the config file. Hence the need to configure the class.

I wasn't sure what to call the setting - `backend_class`, `broker_class`, `huey_class`? Happy to change if you want