### PR TITLE
Add enqueue as an alias for calling a task

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -603,6 +603,9 @@ class TaskWrapper(object):
     def call_local(self, *args, **kwargs):
         return self.func(*args, **kwargs)
 
+    def enqueue(self, *args, **kwargs):
+        return self(*args, **kwargs)
+
     def s(self, *args, **kwargs):
         return self.task_class((args, kwargs), retries=self.retries,
                                retry_delay=self.retry_delay)


### PR DESCRIPTION
Hello, me again.

I'd like to propose an API change (well just an addition for now):

Queueing tasks using `.enqueue()` rather than calling them directly.
My reasoning is that `enqueue()` makes it immediately obvious that the function is going to be run async and return a `TaskResultWrapper`.  Without making this distinction between function calls and async task execution I think it's easy to make mistakes that lead to subtle timing bugs, especially for people that are new to a codebase and may not know a function is actually a task. Consider this contrived example:

```python
def handle_request():
    do_a_thing()
    task_with_side_effect()
    thing_that_relies_on_side_effect()
    return 200
```
`thing_that_relies_on_side_effect` is going to fail here, possibly inconsistently, because it relies on `task_with_side_effect` running first.

If I'm using djhuey with the default settings I'm unlikely to catch this in development because `always_eager` will default to `True` in debug mode, whereas if I'd used `task_with_side_effect.enqueue()` the async behaviour would be front of mind and I'd (hopefully) catch this before it went to production.

Obviously this can't be done without breakage, so all I've done here is add an alias so I can take advantage of these benefits in the meantime.

What do you think?