### PR TITLE
Pre-1.6 queued tasks compatibility

### DIFF
--- a/huey/registry.py
+++ b/huey/registry.py
@@ -78,7 +78,8 @@ class TaskRegistry(object):
         """Convert a message from the queue into a task"""
         # parse out the pieces from the enqueued message
         raw = pickle.loads(msg)
-        task_id, klass_str, execute_time, retries, delay, data, oc_raw = raw
+
+        task_id, klass_str, execute_time, retries, delay, data, oc_raw = (raw + [None])[:7]
 
         klass = self.get_task_class(klass_str)
         on_complete = self.get_task_for_message(oc_raw) if oc_raw else None


### PR DESCRIPTION
*Huey 1.6* introduces support for tasks pipelining, and therefore modifies the structure of pickled tasks in the queue.

When upgrading from 1.5- to 1.6, all the previous tasks can no longer run due to this, resulting in `ValueError: need more than 6 values to unpack` exceptions. This is particularly annoying as users have to flush the queue and recreate tasks again, sometimes for things planned months in advance.
Also, there is no mention of this anywhere in the changelog.

This one-line fix allows to execute old tasks using the latest code without hassle.
IMHO given the impact, this should be merged and released ASAP.