### PR TITLE
allow django connection pooling

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 from django.conf import settings
-from django.db import connection
+from django.db import close_old_connections
 
 
 configuration_message = """
@@ -108,7 +108,7 @@ def close_db(fn):
             return fn(*args, **kwargs)
         finally:
             if not HUEY.always_eager:
-                connection.close()
+                close_old_connections()
     return inner
 
 
@@ -122,3 +122,4 @@ def db_periodic_task(*args, **kwargs):
     def decorator(fn):
         return periodic_task(*args, **kwargs)(close_db(fn))
     return decorator
+


### PR DESCRIPTION
This patch allows django to reuse the db connection when max_conn_age is set in the settings.
Instead of closing every connection this patch only closes the connection when it's broken or obsolete. 
For reference: django calls the same function before and after every request. (https://github.com/django/django/blob/master/django/db/__init__.py#L59)