### PR TITLE
Add global timestamp for periodic tasks scheduler

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,8 +142,11 @@ Function decorators and helpers
 
         .. note::
             By default, the consumer will schedule and enqueue periodic task
-            functions.  To disable the enqueueing of periodic tasks, run the
-            consumer with ``-n`` or ``--no-periodic``.
+            functions if other consumer haven't done that before. If you want
+            periodic tasks to be enqueued on each instance separately run
+            ``-g`` or ``--no-global-scheduler``. To disable the enqueueing of
+            periodic tasks on a consumer, run the consumer with
+            ``-n`` or ``--no-periodic``.
 
         The ``validate_datetime`` parameter is a function which accepts a datetime
         object and returns a boolean value whether or not the decorated function

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -91,6 +91,11 @@ their default values.
     If you do not plan on using the periodic task feature, feel free to use
     this option to save a few CPU cycles.
 
+``-g``, ``--no-global-scheduler``
+    Indicate that this consumer process should *not* use global scheduler.
+    Use this options if you plan to run scheduler on multiple instances and you
+    want periodic tasks to be enqueued multiple times (once per instance).
+
 ``-d``, ``--delay``
     When using a "polling"-type queue backend, the amount of time to wait
     between polling the backend.  Default is 0.1 seconds. For example, when the

--- a/huey/api.py
+++ b/huey/api.py
@@ -30,6 +30,7 @@ from huey.utils import is_aware
 from huey.utils import is_naive
 from huey.utils import local_to_utc
 from huey.utils import make_naive
+from huey.utils import to_timestamp
 from huey.utils import wrap_exception
 
 
@@ -496,6 +497,16 @@ class Huey(object):
     def get_regular_tasks(self):
         periodic = set(self.get_periodic_tasks())
         return [task for task in self.get_tasks() if task not in periodic]
+
+    def update_last_scheduler_runtime(self, now):
+        """
+        Update periodic task scheduler last run time using Storage key/value
+        API. If the operations succeeded it returns amount of seconds since
+        previous run
+        """
+
+        ts = to_timestamp(now.replace(second=0, microsecond=0))
+        return self.storage.put_if_higher('periodic_tasks_last_run', int(ts))
 
     def lock_task(self, lock_name):
         """

--- a/huey/consumer_options.py
+++ b/huey/consumer_options.py
@@ -17,6 +17,7 @@ config_defaults = (
     ('health_check_interval', 1),
     ('scheduler_interval', 1),
     ('periodic', True),
+    ('global_scheduler', True),
     ('utc', True),
     ('logfile', None),
     ('verbose', None),
@@ -69,11 +70,14 @@ class OptionParserHandler(object):
 
     def get_scheduler_options(self):
         return (
-            # -s, -n, -u, -o
+            # -s, -n, -g, -u, -o
             option('scheduler_interval', type='int',
                    help='Granularity of scheduler in seconds.'),
             option('no_periodic', action='store_false',
                    dest='periodic', help='do NOT enqueue periodic tasks'),
+            option(('g', 'no-global-scheduler'), action='store_false',
+                   dest='global_scheduler',
+                   help='do NOT ensure global periodic tasks schedule'),
             option('utc', action='store_true',
                    help='use UTC time for all tasks (default=True)'),
             option(('o', 'localtime'), action='store_false', dest='utc',

--- a/huey/contrib/sqlitedb.py
+++ b/huey/contrib/sqlitedb.py
@@ -128,7 +128,10 @@ class SqliteStorage(BaseStorage):
         return Schedule.delete().where(Schedule.queue == self.name).execute()
 
     def put_data(self, key, value):
-        KeyValue.create(queue=self.name, key=key, value=value)
+        if self.has_data_for_key(key):
+            KeyValue.update(queue=self.name, key=key, value=value)
+        else:
+            KeyValue.create(queue=self.name, key=key, value=value)
 
     def peek_data(self, key):
         try:

--- a/huey/tests/test_sqlite.py
+++ b/huey/tests/test_sqlite.py
@@ -46,6 +46,12 @@ class TestSqliteStorage(HueyTestCase):
         self.assertEqual(storage.pop_data('k1'), '3')
         self.assertEqual(storage.pop_data('k2'), '4')
 
+    def test_put_if_higher(self):
+        storage = self.huey.storage
+        self.assertEqual(storage.put_if_higher('k1', 3), 3)
+        self.assertEqual(storage.put_if_higher('k1', 2), 0)
+        self.assertEqual(storage.put_if_higher('k1', 5), 2)
+
     def test_schedule(self):
         dt1 = datetime.datetime(2013, 1, 1, 0, 0)
         dt2 = datetime.datetime(2013, 1, 2, 0, 0)

--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -43,6 +43,12 @@ class TestRedisStorage(HueyTestCase):
         storage.put_data('k3', 'v3-2')
         self.assertEqual(storage.peek_data('k3'), b('v3-2'))
 
+    def test_put_if_higher(self):
+        storage = self.huey.storage
+        self.assertEqual(storage.put_if_higher('k1', 3), 3)
+        self.assertEqual(storage.put_if_higher('k1', 2), 0)
+        self.assertEqual(storage.put_if_higher('k1', 5), 2)
+
     def test_schedules(self):
         storage = self.huey.storage
         dt1 = datetime.datetime(2013, 1, 1, 0, 0)

--- a/huey/utils.py
+++ b/huey/utils.py
@@ -74,3 +74,11 @@ def local_to_utc(dt):
     Converts a naive local datetime.datetime in UTC time zone.
     """
     return datetime.datetime(*time.gmtime(time.mktime(dt.timetuple()))[:6])
+
+
+def to_timestamp(dt):
+    """
+    Converts datetime.datetime to timestamp
+    """
+    if dt:
+        return time.mktime(dt.timetuple())


### PR DESCRIPTION
This PR adds global timestamp for periodic tasks scheduler. If periodic tasks are scheduled by multiple instance it prevents the task from being scheduled multiple times.

This options can be disabled by -g or --no-global-scheduler