### PR TITLE
Consumer.run(): reduce latency by removing superfluous sleep

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -664,7 +664,6 @@ class Consumer(object):
         while True:
             try:
                 is_set = self.stop_flag.wait(timeout=timeout)
-                time.sleep(timeout)
             except KeyboardInterrupt:
                 self._logger.info('Received SIGINT')
                 self.stop(graceful=True)


### PR DESCRIPTION
Unless I'm missing something (which is entirely possible) the consumer waits too long in the `.run()` method.

`stop_flag.wait()` already waits for `timeout` seconds. The additional `time.sleep()` is superfluous and effectively doubles the sleep time (or increases latency until the consumer process reacts to a stop commands/checks worker health).

The code was added in commit 64e69c5ba998f61840469a5264aa6ddc6c18bbac but that commit does not mention why we need the additional `time.sleep()` so I guess this was just a mistake.