### PR TITLE
Add task finished log message

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -287,6 +287,7 @@ class Worker(BaseProcess):
                 duration=duration)
             exception = exc
         else:
+            self._logger.info('Task %s finished in %0.3fs', task, duration)
             self.huey.emit_task(
                 EVENT_FINISHED,
                 task,

--- a/huey/tests/test_consumer.py
+++ b/huey/tests/test_consumer.py
@@ -243,7 +243,7 @@ class TestConsumerAPIs(ConsumerTestCase):
             res = modify_state('k', 'v')
             worker.loop()
 
-        self.assertLogs(capture, ['Executing %s' % res.task])
+        self.assertLogs(capture, ['Executing %s' % res.task, 'Task %s finished in' % res.task])
 
         self.assertEqual(state, {'k': 'v'})
         self.assertEqual(res.get(), 'v')


### PR DESCRIPTION
Hi
I want to add task finished info log message as every other possible task end state / failure has it's own error/exception/info message already. 
I'm aware of `self._logger.debug('Task %s ran in %0.3fs', task, duration)` message, but that is for debug purposes and it gets logged every time (no matter if the task failed or not)

What I want to see in the log for the healthy operating Huey is a sequence of 
```
Executing task:xyx
Task xyz finished in 123s
```
This new message will help to monitor tasks performance, long running tasks and helps to find possible stuck / never finished tasks.

Let me know what do you think and if there is anything I shall do to make this Pull Request accepted.
Cheers

