### PR TITLE
Fix SyntaxWarning due to unescaped sequence

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -924,8 +924,8 @@ def create_task(task_class, func, retries_as_argument=False, task_name=None,
     return type(task_name, (task_class,), attrs)
 
 
-dash_re = re.compile('(\d+)-(\d+)')
-every_re = re.compile('\*\/(\d+)')
+dash_re = re.compile(r'(\d+)-(\d+)')
+every_re = re.compile(r'\*\/(\d+)')
 
 
 def crontab(month='*', day='*', day_of_week='*', hour='*', minute='*'):


### PR DESCRIPTION
This PR fixes a `SyntaxWarning` introduced in CPython master. This is due to unescaped sequence and the one possible fix would be to use a raw string. Reference warning in CI for 3.8-dev : https://travis-ci.org/coleifer/huey/jobs/478435016#L461

Thanks :)