### PR TITLE
fix crontab import

### DIFF
--- a/examples/django_ex/djangoex/test_app/tasks.py
+++ b/examples/django_ex/djangoex/test_app/tasks.py
@@ -1,5 +1,6 @@
 import random
-from huey.contrib.djhuey import task, periodic_task, crontab, db_task
+from huey import crontab
+from huey.contrib.djhuey import task, periodic_task, db_task
 
 
 @task()


### PR DESCRIPTION
django example had crontab being imported from huey.contrib.djhuey  instead of huey.