### PR TITLE
WIP: add signed serializer

### DIFF
--- a/huey/serializer.py
+++ b/huey/serializer.py
@@ -1,3 +1,5 @@
+import hashlib
+import hmac
 try:
     import gzip
 except ImportError:
@@ -27,3 +29,58 @@ class Serializer(object):
 
     def deserialize(self, data):
         return self._deserialize(gzip.decompress(data) if self.comp else data)
+
+
+# identical to django.utils.crypto.constant_time_compare
+def _constant_time_compare(val1, val2):
+    """Return True if the two strings are equal, False otherwise."""
+    return hmac.compare_digest(val1, val2)
+
+
+class SignedSerializer(Serializer):
+    def __init__(self, secret="", salt="huey", **kwargs):
+        super().__init__(**kwargs)
+
+        if not secret:
+            raise ConfigurationError("A secret is required")
+
+        if not salt:
+            raise ConfigurationError("A salt is required")
+
+        self.secret = secret.encode("utf-8")
+        self.salt = salt.encode("utf-8")
+
+        # if you change the separator, make sure it doesn't contain
+        # any of [a-zA-Z0-9]
+        self.separator = b":"
+
+    def _signature(self, message: bytes):
+        # same key derivation as django.utils.crypto.salted_hmac
+        key = hashlib.sha1(self.salt + self.secret).digest()
+        signature = hmac.new(key, msg=message, digestmod=hashlib.sha1)
+
+        # we need to make sure that our digest can't contain the separator
+        return signature.hexdigest().encode("utf-8")
+
+    def _sign(self, message: bytes) -> bytes:
+        signature = self._signature(message)
+        return message + self.separator + signature
+
+    def _unsign(self, signed_value: bytes) -> bytes:
+        if self.separator not in signed_value:
+            raise ValueError('Separator "%s" not found in value' % self.separator)
+
+        value, sig = signed_value.rsplit(self.separator, 1)
+
+        if _constant_time_compare(sig, self._signature(value)):
+            return value
+
+        raise ValueError('Signature "%s" does not match' % sig)
+
+    def _serialize(self, data):
+        serialized = super()._serialize(data)
+        return self._sign(serialized)
+
+    def _deserialize(self, data):
+        unsigned = self._unsign(data)
+        return super()._deserialize(unsigned)

--- a/huey/serializer.py
+++ b/huey/serializer.py
@@ -39,7 +39,7 @@ def _constant_time_compare(val1, val2):
 
 class SignedSerializer(Serializer):
     def __init__(self, secret="", salt="huey", **kwargs):
-        super().__init__(**kwargs)
+        super(SignedSerializer, self).__init__(**kwargs)
 
         if not secret:
             raise ConfigurationError("A secret is required")
@@ -54,7 +54,7 @@ class SignedSerializer(Serializer):
         # any of [a-zA-Z0-9]
         self.separator = b":"
 
-    def _signature(self, message: bytes):
+    def _signature(self, message):
         # same key derivation as django.utils.crypto.salted_hmac
         key = hashlib.sha1(self.salt + self.secret).digest()
         signature = hmac.new(key, msg=message, digestmod=hashlib.sha1)
@@ -62,11 +62,11 @@ class SignedSerializer(Serializer):
         # we need to make sure that our digest can't contain the separator
         return signature.hexdigest().encode("utf-8")
 
-    def _sign(self, message: bytes) -> bytes:
+    def _sign(self, message):
         signature = self._signature(message)
         return message + self.separator + signature
 
-    def _unsign(self, signed_value: bytes) -> bytes:
+    def _unsign(self, signed_value):
         if self.separator not in signed_value:
             raise ValueError('Separator "%s" not found in value' % self.separator)
 
@@ -78,9 +78,9 @@ class SignedSerializer(Serializer):
         raise ValueError('Signature "%s" does not match' % sig)
 
     def _serialize(self, data):
-        serialized = super()._serialize(data)
+        serialized = super(SignedSerializer, self)._serialize(data)
         return self._sign(serialized)
 
     def _deserialize(self, data):
         unsigned = self._unsign(data)
-        return super()._deserialize(unsigned)
+        return super(SignedSerializer, self)._deserialize(unsigned)

--- a/huey/tests/test_api.py
+++ b/huey/tests/test_api.py
@@ -13,6 +13,7 @@ from huey.exceptions import ConfigurationError
 from huey.exceptions import RetryTask
 from huey.exceptions import TaskException
 from huey.exceptions import TaskLockedException
+from huey.serializer import SignedSerializer
 from huey.tests.base import BaseTestCase
 
 
@@ -1112,6 +1113,10 @@ class TestHueyAPIs(BaseTestCase):
         self.assertEqual(ta, S(ta))
         self.assertEqual(tb, S(tb))
         self.assertEqual(tp, S(tp))
+
+    def test_serialize_deserialize_signed(self):
+        self.huey.serializer = SignedSerializer(secret="this-is-a-secret")
+        return self.test_serialize_deserialize()
 
     def test_put_get(self):
         tests = ('v1', 1, 1., 0, None,


### PR DESCRIPTION
Hi Charles,

first of all, thank you for making huey. It really is a pleasure to use.

There is really only one thing that I didn't love about huey, and that is
the security implications of un-pickleing any old data from e.g. redis.
Given that huey now has a nice abstraction for serializers, I've just
implemented a simple `SignedSerializer` based on django's Signer.

Right now the implementation is python3 only. If you'd be interested
in merging this and if you plan to continue support for python 2 I'd
be happy to add support for python 2 as well.

While having a signed serializer for my own work will satisfy my
security concerns, I'd also suggest moving towards using a signed 
serializer by default at some point in the future.
This would reduce the attack surface for the average user and people
who need the highest possible throughput could still easily use the
unsigned serializer if need be.

Thanks again and have a great weekend!

Raphael 

/edit I've added a commit that makes the tests pass on python2