### PR TITLE
fix inconsistent timezone in test_api.py and serializer

### DIFF
--- a/huey/serializer.py
+++ b/huey/serializer.py
@@ -1,7 +1,7 @@
 try:
-    import gzip
+    import zlib
 except ImportError:
-    gzip = None
+    zlib = None
 import pickle
 
 from huey.exceptions import ConfigurationError
@@ -11,8 +11,8 @@ class Serializer(object):
     def __init__(self, compression=False, compression_level=6):
         self.comp = compression
         self.comp_level = compression_level
-        if self.comp and gzip is None:
-            raise ConfigurationError('Cannot enable compression, gzip module '
+        if self.comp and zlib is None:
+            raise ConfigurationError('Cannot enable compression, zlib module '
                                      'not found.')
 
     def _serialize(self, data):
@@ -23,7 +23,7 @@ class Serializer(object):
 
     def serialize(self, data):
         data = self._serialize(data)
-        return gzip.compress(data, self.comp_level) if self.comp else data
+        return zlib.compress(data, self.comp_level) if self.comp else data
 
     def deserialize(self, data):
-        return self._deserialize(gzip.decompress(data) if self.comp else data)
+        return self._deserialize(zlib.decompress(data) if self.comp else data)

--- a/huey/tests/__init__.py
+++ b/huey/tests/__init__.py
@@ -4,6 +4,7 @@ from huey.tests.test_crontab import *
 from huey.tests.test_immediate import *
 from huey.tests.test_priority import *
 from huey.tests.test_registry import *
+from huey.tests.test_serializer import *
 from huey.tests.test_signals import *
 from huey.tests.test_sql_huey import *
 from huey.tests.test_storage import *

--- a/huey/tests/test_api.py
+++ b/huey/tests/test_api.py
@@ -549,7 +549,7 @@ class TestQueue(BaseTestCase):
         self.assertEqual(task.retries, 1)
         self.assertFalse(self.huey.ready_to_run(task))
 
-        dt = datetime.datetime.utcnow() + datetime.timedelta(seconds=61)
+        dt = datetime.datetime.now() + datetime.timedelta(seconds=61)
         self.assertTrue(self.huey.ready_to_run(task, dt))
 
     def test_retry_delay_periodic(self):
@@ -568,7 +568,7 @@ class TestQueue(BaseTestCase):
         self.assertEqual(task.retries, 1)
         self.assertFalse(self.huey.ready_to_run(task))
 
-        dt = datetime.datetime.utcnow() + datetime.timedelta(seconds=61)
+        dt = datetime.datetime.now() + datetime.timedelta(seconds=61)
         self.assertTrue(self.huey.ready_to_run(task, dt))
 
     def test_retrytask_explicit(self):

--- a/huey/tests/test_serializer.py
+++ b/huey/tests/test_serializer.py
@@ -1,0 +1,29 @@
+import datetime
+
+from huey.api import MemoryHuey
+from huey.api import PeriodicTask
+from huey.api import Result
+from huey.api import Task
+from huey.api import TaskWrapper
+from huey.api import crontab
+from huey.api import _unsupported
+from huey.constants import EmptyData
+from huey.exceptions import CancelExecution
+from huey.exceptions import ConfigurationError
+from huey.exceptions import RetryTask
+from huey.exceptions import TaskException
+from huey.exceptions import TaskLockedException
+from huey.serializer import Serializer
+from huey.tests.base import BaseTestCase
+
+
+class TestSerializer(BaseTestCase):
+    def test_serialize(self):
+        serializer = Serializer()
+        data = 1
+        serialized_data = serializer.serialize(data)
+        self.assertEqual(serializer.deserialize(serialized_data), data)
+
+        serializer = Serializer(compression=True)
+        serialized_data = serializer.serialize(data)
+        self.assertEqual(serializer.deserialize(serialized_data), data)

--- a/huey/tests/test_serializer.py
+++ b/huey/tests/test_serializer.py
@@ -1,18 +1,3 @@
-import datetime
-
-from huey.api import MemoryHuey
-from huey.api import PeriodicTask
-from huey.api import Result
-from huey.api import Task
-from huey.api import TaskWrapper
-from huey.api import crontab
-from huey.api import _unsupported
-from huey.constants import EmptyData
-from huey.exceptions import CancelExecution
-from huey.exceptions import ConfigurationError
-from huey.exceptions import RetryTask
-from huey.exceptions import TaskException
-from huey.exceptions import TaskLockedException
 from huey.serializer import Serializer
 from huey.tests.base import BaseTestCase
 


### PR DESCRIPTION
The huey object is created with utc=False.