### PR TITLE
Added python versions so django packages shows Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     test_suite='runtests.runtests',
     entry_points={


### PR DESCRIPTION
Django Packages uses setup.py to determine whether a package supports Python 3.

[Huey's django packages entry](https://djangopackages.org/packages/p/huey/) currently does not show that Python 3 is supported.

This pull request simply updates setup.py to show support for Python 2.7+ & 3.4+