### PR TITLE
Add Write-Ahead Log option to SQLite storage

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -100,6 +100,7 @@ Huey types
     :param int cache_mb: megabytes of memory to allow for sqlite page-cache.
     :param bool fsync: use durable writes. Slower but more resilient to
         corruption in the event of sudden power loss. Defaults to false.
+    :param bool wal: use Write-Ahead Log mode. Defaults to false.
 
     SqliteHuey fully supports task priorities.
 
@@ -1352,13 +1353,16 @@ Huey comes with several built-in storage implementations:
     automatically cleaned-up.
 
 
-.. py:class:: SqliteStorage(filename='huey.db', name='huey', cache_mb=8, fsync=False, **kwargs)
+.. py:class:: SqliteStorage(filename='huey.db', name='huey', cache_mb=8, fsync=False, wal=False, **kwargs)
 
     :param str filename: sqlite database filename.
     :param int cache_mb: sqlite page-cache size in megabytes.
     :param bool fsync: if enabled, all writes to the Sqlite database will be
         synchonized. This provides greater safety from database corruption in
         the event of sudden power-loss.
+    :param bool wal: if enabled, Write-Ahead Log journal mode will be used.
+        This provides more concurrency but requires processes using the database
+        to be on the same host computer.
     :param kwargs: Additional keyword arguments passed to the ``sqlite3``
         connection constructor.
 

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -674,7 +674,7 @@ class SqliteStorage(BaseStorage):
                 self._state.reset()
 
     def initialize_schema(self):
-        self.sql('pragma journal_mode=%s' % ("wal" if self._wal else "delete"))
+        self.sql('pragma journal_mode=%s' % ('wal' if self._wal else 'delete'))
         with self.db(commit=True, close=True) as conn:
             for sql in self.ddl:
                 conn.execute(sql)

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -627,11 +627,12 @@ class SqliteStorage(BaseStorage):
     ddl = [table_kv, table_sched, index_sched, table_task, index_task]
 
     def __init__(self, name='huey', filename='huey.db', cache_mb=8,
-                 fsync=False, **kwargs):
+                 fsync=False, wal=False, **kwargs):
         super(SqliteStorage, self).__init__(name)
         self.filename = filename
         self._cache_mb = cache_mb
         self._fsync = fsync
+        self._wal = wal
         self._conn_kwargs = kwargs
         self._state = _ConnectionLocal()
         self.initialize_schema()
@@ -673,6 +674,7 @@ class SqliteStorage(BaseStorage):
                 self._state.reset()
 
     def initialize_schema(self):
+        self.sql('pragma journal_mode=%s' % ("WAL" if self._wal else "delete"))
         with self.db(commit=True, close=True) as conn:
             for sql in self.ddl:
                 conn.execute(sql)

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -674,7 +674,7 @@ class SqliteStorage(BaseStorage):
                 self._state.reset()
 
     def initialize_schema(self):
-        self.sql('pragma journal_mode=%s' % ("WAL" if self._wal else "delete"))
+        self.sql('pragma journal_mode=%s' % ("wal" if self._wal else "delete"))
         with self.db(commit=True, close=True) as conn:
             for sql in self.ddl:
                 conn.execute(sql)

--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -268,11 +268,11 @@ class TestSqliteStorage(StorageTests, BaseTestCase):
 
 class TestSqliteStorageWithWriteAheadLogEnabled(TestSqliteStorage):
     def get_huey(self):
-        return SqliteHuey(filename='huey_storage_wal.db', wal=True)
+        return SqliteHuey(filename='huey_storage.db', wal=True)
 
     def test_journal_mode(self):
-        journal_mode = self.s.sql("pragma journal_mode", results=True)[0][0]
-        self.assertEqual(journal_mode, "wal")
+        journal_mode = self.s.sql('pragma journal_mode', results=True)[0][0]
+        self.assertEqual(journal_mode, 'wal')
 
 
 class MemFileStorage(FileStorageMethods, MemoryStorage): pass

--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -266,6 +266,15 @@ class TestSqliteStorage(StorageTests, BaseTestCase):
         return SqliteHuey(filename='huey_storage.db')
 
 
+class TestSqliteStorageWithWriteAheadLogEnabled(TestSqliteStorage):
+    def get_huey(self):
+        return SqliteHuey(filename='huey_storage_wal.db', wal=True)
+
+    def test_journal_mode(self):
+        journal_mode = self.s.sql("pragma journal_mode", results=True)[0][0]
+        self.assertEqual(journal_mode, "wal")
+
+
 class MemFileStorage(FileStorageMethods, MemoryStorage): pass
 
 


### PR DESCRIPTION
This adds an option to enable [Write-Ahead Log](https://www.sqlite.org/wal.html) journal for SQLite storage. It provides more concurrent SQLite reads and writes reducing the frequency of "database is locked" type of exceptions.

Some notes:

- `self.sql('pragma journal_mode=%s' % ("WAL" if self._wal else "delete"))` statement is outside the context manager due to `sqlite3.OperationalError: cannot change into wal mode from within a transaction`.
- Looks like WAL mode was available but was lost over time: https://github.com/coleifer/huey/pull/53