### PR TITLE
Put task_id in the meta information of a TaskException

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -373,7 +373,9 @@ class Huey(object):
                 self.put_result(task.id, Error({
                     'error': repr(exception),
                     'retries': task.retries,
-                    'traceback': tb}))
+                    'traceback': tb,
+                    'task_id': task.id,
+                }))
             elif task_value is not None or self.store_none:
                 self.put_result(task.id, task_value)
 


### PR DESCRIPTION
By doing this we can catch the TaskException higher up and still have access to the task_id. Otherwise we need to catch the exception at every place where we try to fetch a result in order to be able to fetch the task_id from the result object.

I don't think adding this extra meta information has any downsides.