### PR TITLE
Fix typo in TaskLockedException docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1283,7 +1283,7 @@ Exceptions
 
     Raised when Huey encounters a configuration problem.
 
-.. py:class:: TaskLockdException
+.. py:class:: TaskLockedException
 
     Raised by the consumer when a task lock cannot be acquired.
 


### PR DESCRIPTION
What a difference a letter makes :)