### PR TITLE
If redis-version >=4.0, use the `unlink` to delete the big key

### DIFF
--- a/huey/storage.py
+++ b/huey/storage.py
@@ -443,7 +443,7 @@ class RedisStorage(BaseStorage):
         return delete_method
 
     def flush_queue(self):
-        self.delete_key(self.queue_key)
+        return self.delete_key(self.queue_key)
 
     def add_to_schedule(self, data, ts, utc):
         self.conn.zadd(self.schedule_key, {data: self.convert_ts(ts)})
@@ -463,7 +463,7 @@ class RedisStorage(BaseStorage):
         return self.conn.zrange(self.schedule_key, 0, limit, withscores=False)
 
     def flush_schedule(self):
-        self.delete_key(self.schedule_key)
+        return self.delete_key(self.schedule_key)
 
     def put_data(self, key, value, is_result=False):
         self.conn.hset(self.result_key, key, value)
@@ -496,7 +496,7 @@ class RedisStorage(BaseStorage):
         return self.conn.hgetall(self.result_key)
 
     def flush_results(self):
-        self.delete_key(self.result_key)
+        return self.delete_key(self.result_key)
 
 
 class RedisExpireStorage(RedisStorage):
@@ -530,7 +530,7 @@ class RedisExpireStorage(RedisStorage):
     pop_data = peek_data
 
     def delete_data(self, key):
-        self.delete_key(self.result_key(key))
+        return self.delete_key(self.result_key(key))
 
     def has_data_for_key(self, key):
         return self.conn.exists(self.result_key(key)) != 0
@@ -556,7 +556,7 @@ class RedisExpireStorage(RedisStorage):
     def flush_results(self):
         keys = list(self._result_keys())
         if keys:
-            self.delete_key(*keys)
+            return self.delete_key(*keys)
 
 
 class RedisPriorityQueue(object):


### PR DESCRIPTION
The `unlink` couldn't block the current thread.