### PR TITLE
Allow a task id to be passed in to instant task scheduling.

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -761,7 +761,8 @@ class TaskWrapper(object):
     def s(self, *args, **kwargs):
         return self.task_class(args, kwargs, retries=self.retries,
                                retry_delay=self.retry_delay,
-                               priority=kwargs.pop('priority', None))
+                               priority=kwargs.pop('priority', None),
+                               id=kwargs.pop('id', None))
 
 
 class TaskLock(object):


### PR DESCRIPTION
Currently there's no option to pass in a task id for tasks that need to be instantly scheduled.
I would be fine with using the `schedule` method instead, as that does allow a task id to be passed in, but if you don't provide an `eta` or a `delay` this methods throws an Exception.

My pull request solves the issue using the `s` method, but perhaps `id` is not the best name for the keyword parameter. I believe `task_id` would be a better name but I wanted to be consistent with the naming in the other function. Let me know if I should make some changes.