### PR TITLE
@db_periodic_task.call_local should not close database connections.

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -146,5 +146,7 @@ def db_task(*args, **kwargs):
 
 def db_periodic_task(*args, **kwargs):
     def decorator(fn):
-        return periodic_task(*args, **kwargs)(close_db(fn))
+        ret = periodic_task(*args, **kwargs)(close_db(fn))
+        ret.call_local = fn
+        return ret
     return decorator


### PR DESCRIPTION
I received an error similar to #296, but for `@db_periodic_task`. It looks like the workaround in `@db_task` needs copying over!