### PR TITLE
Add exception call to AsyncResult after task failing

### DIFF
--- a/huey/contrib/mini.py
+++ b/huey/contrib/mini.py
@@ -90,6 +90,7 @@ class MiniHuey(object):
             ret = fn(*args, **kwargs)
         except Exception as exc:
             logger.exception('task %s failed' % fn.__name__)
+            async_result.set_exception(exc)
             raise
         else:
             duration = time.time() - start


### PR DESCRIPTION
Hi! MiniHuey has a bug - when some exception raises in _execute method, the AsyncResult is not notified about that. So, greenlet is done, but I can't get its status and exception.
```python
def _execute(self, fn, args, kwargs, async_result):
     args = args or ()
     kwargs = kwargs or {}
     start = time.time()
     try:
         ret = fn(*args, **kwargs)
     except Exception as exc:
         logger.exception('task %s failed' % fn.__name__)
         raise
     else:
         duration = time.time() - start

     if async_result is not None:
         async_result.set(ret)
     logger.info('executed %s in %0.3fs', fn.__name__, duration)
```
 I added an exception call to AsyncResult, now it's working fine.