### PR TITLE
Use time.monotonic() instead of time.time() for comparing relative times

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -350,7 +350,7 @@ class Huey(object):
                 self._emit(S.SIGNAL_CANCELED, task)
                 return
 
-        start = time.time()
+        start = time.monotonic()
         exception = None
         task_value = None
 
@@ -358,7 +358,7 @@ class Huey(object):
             try:
                 task_value = task.execute()
             finally:
-                duration = time.time() - start
+                duration = time.monotonic() - start
         except TaskLockedException as exc:
             logger.warning('Task %s not run, unable to acquire lock.', task.id)
             exception = exc
@@ -872,10 +872,10 @@ class Result(object):
             if res is not EmptyData:
                 return res
         else:
-            start = time.time()
+            start = time.monotonic()
             delay = .1
             while self._result is EmptyData:
-                if timeout and time.time() - start >= timeout:
+                if timeout and time.monotonic() - start >= timeout:
                     if revoke_on_timeout:
                         self.revoke()
                     raise HueyException('timed out waiting for result')

--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -144,13 +144,13 @@ class Scheduler(BaseProcess):
         self.interval = min(interval, 60)
 
         self.periodic = periodic
-        self._next_loop = time.time()
-        self._next_periodic = time.time()
+        self._next_loop = time.monotonic()
+        self._next_periodic = time.monotonic()
 
     def loop(self, now=None):
         current = self._next_loop
         self._next_loop += self.interval
-        if self._next_loop < time.time():
+        if self._next_loop < time.monotonic():
             self._logger.debug('scheduler skipping iteration to avoid race.')
             return
 
@@ -165,7 +165,7 @@ class Scheduler(BaseProcess):
 
         if self.periodic:
             current_p = self._next_periodic
-            if current_p <= time.time():
+            if current_p <= time.monotonic():
                 self._next_periodic += 60
                 self.enqueue_periodic_tasks(now, current)
 
@@ -419,7 +419,7 @@ class Consumer(object):
         """
         self.start()
         timeout = self._stop_flag_timeout
-        health_check_ts = time.time()
+        health_check_ts = time.monotonic()
 
         while True:
             try:
@@ -438,7 +438,7 @@ class Consumer(object):
                 break
 
             if self._health_check:
-                now = time.time()
+                now = time.monotonic()
                 if now >= health_check_ts + self._health_check_interval:
                     health_check_ts = now
                     self.check_worker_health()

--- a/huey/contrib/mini.py
+++ b/huey/contrib/mini.py
@@ -85,7 +85,7 @@ class MiniHuey(object):
     def _execute(self, fn, args, kwargs, async_result):
         args = args or ()
         kwargs = kwargs or {}
-        start = time.time()
+        start = time.monotonic()
         try:
             ret = fn(*args, **kwargs)
         except Exception as exc:
@@ -93,7 +93,7 @@ class MiniHuey(object):
             async_result.set_exception(exc)
             raise
         else:
-            duration = time.time() - start
+            duration = time.monotonic() - start
 
         if async_result is not None:
             async_result.set(ret)
@@ -102,7 +102,7 @@ class MiniHuey(object):
     def _run(self):
         logger.info('task runner started.')
         while not self._shutdown.is_set():
-            start = time.time()
+            start = time.monotonic()
             now = datetime.datetime.now()
             if self._last_check + self._periodic_interval <= now:
                 logger.debug('checking periodic task schedule')

--- a/huey/tests/test_consumer.py
+++ b/huey/tests/test_consumer.py
@@ -35,8 +35,8 @@ class TestConsumerIntegration(BaseTestCase):
 
     def schedule_tasks(self, consumer, now=None):
         scheduler = consumer._create_scheduler()
-        scheduler._next_loop = time.time() + 60
-        scheduler._next_periodic = time.time() - 60
+        scheduler._next_loop = time.monotonic() + 60
+        scheduler._next_periodic = time.monotonic() - 60
         scheduler.loop(now)
 
     def test_consumer_schedule_task(self):


### PR DESCRIPTION
`time.time()` isn't reliable for comparing relative times because it is adjustable. `time.monotonic()` is guaranteed to only go forward.

https://docs.python.org/3/library/time.html#time.monotonic

### Needs discussion:

`time.monotonic()` requires Python 3.3 or above. Probably not worth dropping 2.x support for this (though it might make sense to audit to see what real world issues clock adjustments can cause). 

To restore 2.x support we could use https://github.com/atdt/monotonic or try using `time.monotonic()` and if it's not available we fall back to `time.time()`, maybe with a warning?

---

Thanks for the awesome library, I've been using Huey on realpython.com with a Redis backend as a Celery replacement and it's been great ❤️