### PR TITLE
Emit SIGNAL_EXECUTING before logging Executing message

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -339,8 +339,8 @@ class Huey(object):
             logger.warning('Task %s was revoked, not executing', task)
             self._emit(S.SIGNAL_REVOKED, task)
         else:
-            logger.info('Executing %s', task)
             self._emit(S.SIGNAL_EXECUTING, task)
+            logger.info('Executing %s', task)
             return self._execute(task, timestamp)
 
     def _execute(self, task, timestamp):


### PR DESCRIPTION
I'm using huey to run asynchronous tasks for an HTTP API and have configured the log formatter to include request IDs so it's possible to correlate the logs from huey with the logs from our web server and reverse proxy. 

I did this by overriding `huey.enqueue` so that it always adds a `_request_id` kwarg to the task, like so:
```python
class RequestIDHuey(RedisExpireHuey):
    def enqueue(self, task: Task):
        request_id = context.get("X-Request-ID", "-")
        if request_id:
            task.kwargs["_request_id"] = request_id
        return super().enqueue(task)
```
(By the way, it would be great if there were a `SIGNAL_ENQUEUE` signal that ran before tasks were enqueued so I wouldn't have to override the method like this.)

I then create a function that listens for the `SIGNAL_EXECUTING` signal so it can pop the `_request_id` kwarg and add it to a thread local variable for the consumer process.
```python
@worker.signal(SIGNAL_EXECUTING)
def get_request_id(_: str, task: Task):
    if "_request_id" in task.kwargs:
        local.request_id = task.kwargs.pop("_request_id")
```

The log formatter can then check the thread local variable and add the request ID to the log message.
```python
class HueyTaskFormatter(logging.Formatter):
    def formatMessage(self, record):
        request_id = getattr(local, "request_id", "-")
        record.__dict__.update({"request_id": request_id})
        return super().formatMessage(record)
```

This produces logs that look like this (`backend` is our web server and `worker` is huey):
```
backend_1   | [71be2cc6988846e9376d951994c4eb44] GET /api/test HTTP/1.1 200 OK
nginx_1     | [71be2cc6988846e9376d951994c4eb44] [2020-05-28T04:26:26+00:00] 172.21.0.1 200 "GET /api/test HTTP/1.1" 23 "-" "Mozilla/5.0 (X11; Linux x86_64) ..."
worker_1    | [-] [INFO] [api] Executing projects.tasks.task_example: 120f84bb-4139-4433-a80c-d352ba875304
worker_1    | [71be2cc6988846e9376d951994c4eb44] [INFO] [tasks] Querying db...
worker_1    | [71be2cc6988846e9376d951994c4eb44] [INFO] [api] projects.tasks.task_example: 120f84bb-4139-4433-a80c-d352ba875304 executed in 0.052s
```

You'll notice that the first worker log message has `-` instead of a request ID because huey's "Executing ..." message was logged before the signal was emitted.

This PR makes it so that huey emits the `SIGNAL_EXECUTING` signal before logging the message so that a signal listener can add extra logging context before the message is logged.