### PR TITLE
warn if stale locks are found on startup

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -573,6 +573,13 @@ class Huey(object):
     def lock_task(self, lock_name):
         return TaskLock(self, lock_name)
 
+    def get_locks(self):
+        locks = set()
+        for lock_key in self._locks:
+            if self.get_raw(lock_key) is not EmptyData:
+                locks.add(lock_key.split(".lock.", 1)[-1])
+        return locks
+
     def flush_locks(self):
         flushed = set()
         for lock_key in self._locks:

--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -298,6 +298,8 @@ class Consumer(object):
         # a lock, this ensures that all locks are flushed before starting.
         if flush_locks:
             self.flush_locks()
+        else:
+            self.check_locks()
 
         # Create the scheduler process (but don't start it yet).
         scheduler = self._create_scheduler()
@@ -313,6 +315,14 @@ class Consumer(object):
             # The worker impl is not currently referenced in any consumer code,
             # but it is referenced in the test-suite.
             self.worker_threads.append((worker, process))
+
+    def check_locks(self):
+        locks = self.huey.get_locks()
+        if locks:
+            self._logger.warning(
+                "Found potential stale locks: %s\n"
+                "You can use -f to flush stale locks on startup." % (
+                    ", ".join(key for key in flushed)))
 
     def flush_locks(self):
         self._logger.debug('Flushing locks before starting up.')


### PR DESCRIPTION
I'm not sure if you think this is a good idea, 
but after spending some time tracking down 
a stale lock just now, I thought it might be neat
if the logs kind of warned you about that situation :-)