### PR TITLE
Fix FileLock. Avoid never releasing the file lock.

### DIFF
--- a/huey/utils.py
+++ b/huey/utils.py
@@ -147,8 +147,8 @@ class FileLock(object):
     def release(self):
         if self.fd is not None:
             os.close(self.fd)
-            os.unlink(self.filename)
             self.fd = None
+            os.unlink(self.filename)
 
     def __enter__(self):
         self.acquire()


### PR DESCRIPTION
`utils.FileLock` could not release lock correctly in some cases.
I found this when executing `runtests.py` in my VM (python 3.7.6 / Ubuntu 19.10 / CPU 4 cores / RAM 16GB).

### Analysis
Current:  `lock(os.open)` -> ` create fd` -> `user code`  -> `unlock(os.unlink)`  -> `destroy fd`
Correct:  `lock(os.open)` -> ` create fd` -> `user code`  -> `destroy fd` -> `unlock(os.unlink)`

Error example in multi-threaded environment:
1. `thread1` grabs the lock, and unlocks before destroying `fd`. Here OS scheduler comes in.
2. OS scheduler lets `thread2` grab the lock. Then `thread2` creates `fd` and does its work.
3. OS scheduler lets `thread1` go on. `thread1` destroys `fd`.
4. Now `fd` is not valid any more. As per the code, `thread2` has no chance to release lock afterwards.

### Timeline
Error timeline
```
thread1--[[open--create_fd--user_code--unlink]]------------------------destroy_fd------END
thread2----------------------------------------------[[open--create_fd---user_code---NO_FD--...
```
Correct timeline
```
thread1--[[open--create_fd--user_code--destroy_fd--unlink]]---END
thread2------------------------------------------------------------[[open--...]]
```

### Test
After fix the FileLock locally, `tests.test_storage.TestFileStorageMethods.test_fs_multithreaded` runs way better.
Before the fix it is nearly impossible to pass this test and always takes long time to complete the test.
With the fix have more than 90% possibility to pass it fast.

### Other methods
Use a thread lock when operating on fd and file. Maybe a little bit complex but easier to reason about.
I think this simple fix without other locks is adequate for now. 