### PR TITLE
Fix test_fs_multithreaded order check

### DIFF
--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -364,10 +364,10 @@ class TestFileStorageMethods(StorageTests, BaseTestCase):
         self.assertEqual(out_q.qsize(), nthreads * ntasks)
         self.assertEqual(self.huey.pending_count(), 0)
 
-        # Ensure that the order in which tasks were enqueued is the order in
-        # which they are dequeued.
-        for i in range(nthreads * ntasks):
-            self.assertEqual(in_q.get(), out_q.get())
+        in_data = [in_q.get() for _ in range(nthreads * ntasks)]
+        out_data = [out_q.get() for _ in range(nthreads * ntasks)]
+        self.assertEqual(len(set(out_data)), nthreads * ntasks)
+        self.assertEqual(set(in_data), set(out_data))
 
     @unittest.skipIf(TRAVIS, 'skipping test that is flaky on travis-ci')
     def test_consumer_integration(self):


### PR DESCRIPTION
The test code for `test_fs_multithreaded` could not promise the order check. It sometimes breaks. 

### Problem
10 threads would execute `create_tasks` concurrently. Each thread `enqueue` data to storage and then put data to another queue repeatedly.
Since the OS scheduler could take control between storage `enqueue` and memoery queue `put`, the order of items in storage and the order in memory queue are not necessarily the same.
So does the `dequeue` process. 

### Fix methods
1. Delete the order check code.
2. Use thread lock to make storage and memory queue operation atomic. 

Method `2` seems OK at first glance but it makes all the storage operations sequential, which does harm to the test purpose.
I found in fully concurrent enrivonment it is impossible to record order without help of storage internal api, which does not exist.

Original order check code has two meanings, in_q and out_q have same content, and also have same order.
So I replace order check code with content check code. 