### PR TITLE
Fix python setup.py test

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -9,7 +9,7 @@ import unittest
 from huey import tests
 
 
-def collect_tests(args):
+def collect_tests(args=None):
     suite = unittest.TestSuite()
 
     if not args:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-    test_suite='runtests.runtests',
+    test_suite='runtests.collect_tests',
     entry_points={
         'console_scripts': [
             'huey_consumer = huey.bin.huey_consumer:consumer_main'


### PR DESCRIPTION
`python setup.py test` is not usable.  Fix by reusing `collect_tests` as test suite.