### PR TITLE
Override djhuey multiprocessing method to 'fork' on MacOS with Python 3.8+

### DIFF
--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -47,6 +47,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         from huey.contrib.djhuey import HUEY
 
+        if sys.version_info >= (3, 8) and sys.platform == "darwin":
+            import multiprocessing
+            multiprocessing.set_start_method("fork")
+
         consumer_options = {}
         try:
             if isinstance(settings.HUEY, dict):


### PR DESCRIPTION
https://github.com/coleifer/huey/commit/bf002c85ae444954c3237fa4b056fbf9111448a1 fixed issue https://github.com/coleifer/huey/issues/473 when `huey` is used standalone, but not when running `djhuey` with Django on MacOS (10.15.6) with Python 3.8.

Any chance we can get the workaround from https://github.com/coleifer/huey/commit/bf002c85ae444954c3237fa4b056fbf9111448a1 also on the `djhuey` entry-point?