### PR TITLE
Do not crash in macos BigSur when Python 3.8+ is in use

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -240,9 +240,6 @@ WORKER_TO_ENVIRONMENT = {
     WORKER_PROCESS: ProcessEnvironment,
 }
 
-        if sys.version_info >= (3, 8) and sys.platform.lower() == 'darwin':
-            import multiprocessing
-            multiprocessing.set_start_method('fork')
 
 class Consumer(object):
     """
@@ -258,6 +255,10 @@ class Consumer(object):
                  backoff=1.15, max_delay=10.0, scheduler_interval=1,
                  worker_type=WORKER_THREAD, check_worker_health=True,
                  health_check_interval=10, flush_locks=False):
+
+        if sys.version_info >= (3, 8) and sys.platform.lower() == 'darwin':
+            import multiprocessing
+            multiprocessing.set_start_method('fork')
 
         self._logger = logging.getLogger('huey.consumer')
         if huey.immediate:

--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -240,6 +240,9 @@ WORKER_TO_ENVIRONMENT = {
     WORKER_PROCESS: ProcessEnvironment,
 }
 
+        if sys.version_info >= (3, 8) and sys.platform.lower() == 'darwin':
+            import multiprocessing
+            multiprocessing.set_start_method('fork')
 
 class Consumer(object):
     """


### PR DESCRIPTION
This PR is addressing issue when using huery with Python 3.8+ and MacOS BigSur, we're getting below error

```
  File "/opt/homebrew/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/opt/homebrew/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object 'Consumer._create_process.<locals>._run'
```