### PR TITLE
Use create_consumer in Django run_huey command

### DIFF
--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.module_loading import autodiscover_modules
 
-from huey.consumer import Consumer
 from huey.consumer_options import ConsumerConfig
 from huey.consumer_options import OptionParserHandler
 
@@ -82,5 +81,5 @@ class Command(BaseCommand):
         if not logger.handlers:
             config.setup_logger(logger)
 
-        consumer = Consumer(HUEY, **config.values)
+        consumer = HUEY.create_consumer(**config.values)
         consumer.run()


### PR DESCRIPTION
I have a Huey subclass that overrides the `create_consumer` method, but discovered that the `run_huey` Django management command uses the base `huey.consumer.Consumer` class (and therefore not my subclass). This updates the command to use the `create_consumer` method on the `HUEY` instance instead.