### PR TITLE
Update run_huey.py

### DIFF
--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -50,8 +50,11 @@ class Command(BaseCommand):
         # Python 3.8+ on MacOS uses an incompatible multiprocess model. In this
         # case we must explicitly configure mp to use fork().
         if sys.version_info >= (3, 8) and sys.platform == 'darwin':
-            import multiprocessing
-            multiprocessing.set_start_method('fork')
+            try:
+                import multiprocessing
+                multiprocessing.set_start_method('fork')
+            except:
+                pass
 
         consumer_options = {}
         try:


### PR DESCRIPTION
To fix on some mac os:

`
.8/multiprocessing/context.py", line 243, in set_start_method
    raise RuntimeError('context has already been set')
RuntimeError: context has already been set
(crm) tboulogne@macmini crm % 
`