### PR TITLE
Django multi queue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: package deps
         run: sudo apt-get install kyototycoon libkyototycoon-dev
       - name: pip deps
-        run: pip install gevent redis peewee ukt
+        run: pip install gevent redis peewee ukt django
       - name: runtests
         env:
           HUEY_TRAVIS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_build
 venv/
 huey.egg-info/
 huey.db
+hueyenv/

--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -6,142 +6,14 @@ import traceback
 from django.conf import settings
 from django.db import close_old_connections
 
-
-configuration_message = """
-Configuring Huey for use with Django
-====================================
-
-Huey was designed to be simple to configure in the general case.  For that
-reason, huey will "just work" with no configuration at all provided you have
-Redis installed and running locally.
-
-On the other hand, you can configure huey manually using the following
-setting structure.
-
-The following example uses Redis on localhost, and will run four worker
-processes:
-
-HUEY = {
-    'name': 'my-app',
-    'connection': {'host': 'localhost', 'port': 6379},
-    'consumer': {
-        'workers': 4,
-        'worker_type': 'process',  # "thread" or "greenlet" are other options
-    },
-}
-
-Sometimes you need to configure multiple queues, you can use HUEYS setting for that.
-
-The following example provides two queues. One of them uses Redis on localhost, and will run four worker
-processes. The other one will run two worker processes and its intended to be used for emails:
-
-HUEYS = {
-    'first': {
-        'name': 'my-app',
-        'connection': {'host': 'localhost', 'port': 6379},
-        'consumer': {
-            'workers': 4,
-            'worker_type': 'process',  # "thread" or "greenlet" are other options
-        }
-    },
-    'emails': {
-        'name': 'email',
-        'connection': {'host': 'localhost', 'port': 6379},
-        'consumer': {
-            'workers': 2,
-            'worker_type': 'process',  # "thread" or "greenlet" are other options
-        },
-    },
-}
-
-If you would like to configure Huey's logger using Django's integrated logging
-settings, the logger used by consumer is named "huey".
-
-Alternatively you can simply assign `settings.HUEY` to an actual `Huey`
-object instance:
-
-from huey import RedisHuey
-HUEY = RedisHuey('my-app')
-"""
-
-
-default_backend_path = 'huey.RedisHuey'
-
-def default_queue_name():
-    try:
-        return settings.DATABASE_NAME
-    except AttributeError:
-        try:
-            return settings.DATABASES['default']['NAME']
-        except KeyError:
-            return 'huey'
-
-
-def get_backend(import_path=default_backend_path):
-    module_path, class_name = import_path.rsplit('.', 1)
-    module = import_module(module_path)
-    return getattr(module, class_name)
-
-
-def config_error(msg):
-    print(configuration_message)
-    print('\n\n')
-    print(msg)
-    sys.exit(1)
-
-def configure_instance(huey_config):
-    name = huey_config.pop('name', default_queue_name())
-    if 'backend_class' in huey_config:
-        huey_config['huey_class'] = huey_config.pop('backend_class')
-    backend_path = huey_config.pop('huey_class', default_backend_path)
-    conn_kwargs = huey_config.pop('connection', {})
-    try:
-        del huey_config['consumer']  # Don't need consumer opts here.
-    except KeyError:
-        pass
-    if 'immediate' not in huey_config:
-        huey_config['immediate'] = settings.DEBUG
-    huey_config.update(conn_kwargs)
-
-    try:
-        backend_cls = get_backend(backend_path)
-    except (ValueError, ImportError, AttributeError):
-        config_error('Error: could not import Huey backend:\n%s'
-                     % traceback.format_exc())
-
-    return backend_cls(name, **huey_config)
+from huey.contrib.djhuey.config import DjangoHueySettingsReader
 
 
 HUEY = getattr(settings, 'HUEY', None)
 HUEYS = getattr(settings, 'HUEYS', None)
 
-if HUEY is not None and HUEYS is not None:
-    config_error('Error: HUEY and HUEYS settings are incompatible!')
-
-if HUEY is None and HUEYS is None:
-    try:
-        RedisHuey = get_backend(default_backend_path)
-    except ImportError:
-        config_error('Error: Huey could not import the redis backend. '
-                     'Install `redis-py`.')
-    else:
-        HUEY = RedisHuey(default_queue_name())
-
-if isinstance(HUEY, dict):
-    HUEY = configure_instance(HUEY.copy())
-
-if HUEYS is not None:
-    if not isinstance(HUEYS, dict):
-        config_error('Error: HUEYS must be a dictionary ')
-
-    new_hueys = dict()
-    for queue_name, config in HUEYS.items():
-        huey_config = config.copy()
-        huey_config['name'] = queue_name
-
-        new_hueys[queue_name] = configure_instance(huey_config)
-
-    HUEYS = new_hueys
+config = DjangoHueySettingsReader(HUEY, HUEYS)
+config.configure()
 
 def get_close_db_for_queue(queue):
     def close_db(fn):
@@ -159,13 +31,7 @@ def get_close_db_for_queue(queue):
     return close_db
 
 def default_queue(queue):
-    if HUEYS is not None and queue is None:
-        config_error("""
-If HUEYS is configured run_huey must receive a --queue parameter
-i.e.: 
-python manage.py run_huey --queue first
-            """)
-    return HUEY if HUEY is not None else HUEYS[queue]
+    return config.default_queue(queue)
 
 def task(*args, queue=None, **kwargs):
     return default_queue(queue).task(*args, **kwargs)

--- a/huey/contrib/djhuey/config.py
+++ b/huey/contrib/djhuey/config.py
@@ -1,0 +1,169 @@
+import sys
+
+from importlib import import_module
+from django.conf import settings
+from huey.exceptions import ConfigurationError
+
+
+default_backend_path = 'huey.RedisHuey'
+
+configuration_message = """
+Configuring Huey for use with Django
+====================================
+
+Huey was designed to be simple to configure in the general case.  For that
+reason, huey will "just work" with no configuration at all provided you have
+Redis installed and running locally.
+
+On the other hand, you can configure huey manually using the following
+setting structure.
+
+The following example uses Redis on localhost, and will run four worker
+processes:
+
+HUEY = {
+    'name': 'my-app',
+    'connection': {'host': 'localhost', 'port': 6379},
+    'consumer': {
+        'workers': 4,
+        'worker_type': 'process',  # "thread" or "greenlet" are other options
+    },
+}
+
+Sometimes you need to configure multiple queues, you can use HUEYS setting for that.
+
+The following example provides two queues. One of them uses Redis on localhost, and will run four worker
+processes. The other one will run two worker processes and its intended to be used for emails:
+
+HUEYS = {
+    'first': {
+        'name': 'my-app',
+        'connection': {'host': 'localhost', 'port': 6379},
+        'consumer': {
+            'workers': 4,
+            'worker_type': 'process',  # "thread" or "greenlet" are other options
+        }
+    },
+    'emails': {
+        'name': 'email',
+        'connection': {'host': 'localhost', 'port': 6379},
+        'consumer': {
+            'workers': 2,
+            'worker_type': 'process',  # "thread" or "greenlet" are other options
+        },
+    },
+}
+
+If you would like to configure Huey's logger using Django's integrated logging
+settings, the logger used by consumer is named "huey".
+
+Alternatively you can simply assign `settings.HUEY` to an actual `Huey`
+object instance:
+
+from huey import RedisHuey
+HUEY = RedisHuey('my-app')
+"""
+
+
+
+
+def get_backend(import_path=default_backend_path):
+    module_path, class_name = import_path.rsplit('.', 1)
+    module = import_module(module_path)
+    return getattr(module, class_name)
+
+
+def default_queue_name():
+    try:
+        return settings.DATABASE_NAME
+    except AttributeError:
+        try:
+            return settings.DATABASES['default']['NAME']
+        except KeyError:
+            return 'huey'
+
+
+def config_error(msg):
+    print(configuration_message)
+    print('\n\n')
+    print(msg)
+    sys.exit(1)
+
+class DjangoHueySettingsReader:
+    def __init__(self, huey_setting, hueys_setting):
+        self.huey_setting = huey_setting
+        self.hueys_setting = hueys_setting
+
+        self.huey = None
+        self.hueys = {}
+
+
+    @property
+    def is_single_queue(self):
+        return self.huey_setting is not None
+
+    @property
+    def is_multi_queue(self):
+        return self.hueys_setting is not None
+    
+
+    def configure(self):
+        if self.is_single_queue and self.is_multi_queue:
+            raise ConfigurationError('Error: HUEY and HUEYS settings are incompatible!')
+
+        if not self.is_single_queue and not self.is_multi_queue:
+            try:
+                RedisHuey = get_backend(default_backend_path)
+            except ImportError:
+                config_error('Error: Huey could not import the redis backend. '
+                             'Install `redis-py`.')
+            else:
+                self.huey_setting = RedisHuey(default_queue_name())
+
+        if isinstance(self.huey_setting, dict):
+            self.huey_setting = self._configure_instance(self.huey_setting.copy())
+
+        if self.is_multi_queue:
+            if not isinstance(self.hueys_setting, dict):
+                config_error('Error: HUEYS must be a dictionary ')
+
+            new_hueys = dict()
+            for queue_name, config in self.hueys_setting.items():
+                huey_config = config.copy()
+
+                new_hueys[queue_name] = self._configure_instance(huey_config)
+
+            self.hueys_setting = new_hueys
+
+
+    def default_queue(self, queue):
+        if self.is_multi_queue and queue is None:
+            config_error("""
+If HUEYS is configured run_huey must receive a --queue parameter
+i.e.: 
+python manage.py run_huey --queue first
+                """)
+        return self.huey_setting if self.is_single_queue else self.hueys_setting[queue]
+
+
+    def _configure_instance(self, huey_config):
+        name = huey_config.pop('name', default_queue_name())
+        if 'backend_class' in huey_config:
+            huey_config['huey_class'] = huey_config.pop('backend_class')
+        backend_path = huey_config.pop('huey_class', default_backend_path)
+        conn_kwargs = huey_config.pop('connection', {})
+        try:
+            del huey_config['consumer']  # Don't need consumer opts here.
+        except KeyError:
+            pass
+        if 'immediate' not in huey_config:
+            huey_config['immediate'] = settings.DEBUG
+        huey_config.update(conn_kwargs)
+
+        try:
+            backend_cls = get_backend(backend_path)
+        except (ValueError, ImportError, AttributeError):
+            config_error('Error: could not import Huey backend:\n%s'
+                         % traceback.format_exc())
+
+        return backend_cls(name, **huey_config)

--- a/huey/contrib/djhuey/tests/__init__.py
+++ b/huey/contrib/djhuey/tests/__init__.py
@@ -1,0 +1,1 @@
+from huey.contrib.djhuey.tests.tests_config import *

--- a/huey/contrib/djhuey/tests/settings.py
+++ b/huey/contrib/djhuey/tests/settings.py
@@ -1,0 +1,26 @@
+DEBUG = True
+
+DATABASES = {
+    "default": {
+        'NAME': 'test',
+        "ENGINE": "django.db.backends.sqlite3"
+    }
+}
+
+
+SECRET_KEY = "django_tests_secret_key"
+TIME_ZONE = "America/Chicago"
+LANGUAGE_CODE = "en-us"
+ADMIN_MEDIA_PREFIX = "/static/admin/"
+STATICFILES_DIRS = ()
+
+MIDDLEWARE_CLASSES = []
+
+INSTALLED_APPS = [
+    "huey.contrib.djhuey"
+]
+
+HUEY = {
+    'name': 'test',
+    'always_eager': DEBUG,
+}

--- a/huey/contrib/djhuey/tests/tests_config.py
+++ b/huey/contrib/djhuey/tests/tests_config.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import patch
+
+from huey import RedisHuey, MemoryHuey
+from huey.exceptions import ConfigurationError
+from huey.contrib.djhuey.config import DjangoHueySettingsReader
+
+class DjHueyTests(unittest.TestCase):
+    def test_djhuey_config_with_no_settings(self):
+        config = DjangoHueySettingsReader(None, None)
+
+        self.assertFalse(config.is_single_queue)
+        self.assertFalse(config.is_multi_queue)
+
+    def test_djhuey_config_with_huey_setting(self):
+        HUEY = {
+            'name': 'test',
+            'always_eager': True,
+        }
+        config = DjangoHueySettingsReader(HUEY, None)
+
+        self.assertTrue(config.is_single_queue)
+        self.assertFalse(config.is_multi_queue)
+
+    def test_djhuey_config_with_hueys_setting(self):
+        HUEYS = {
+            'queuename': {
+                'name': 'test',
+                'always_eager': True,
+            }
+        }
+        config = DjangoHueySettingsReader(None, HUEYS)
+
+        self.assertFalse(config.is_single_queue)
+        self.assertTrue(config.is_multi_queue)
+
+    def test_djhuey_configure_raises_error_when_both_settings_are_defined(self):
+        HUEY = {
+            'name': 'test',
+            'always_eager': True,
+        }
+
+        HUEYS = {
+            'queuename': {
+                'name': 'test',
+                'always_eager': True,
+            }
+        }
+        config = DjangoHueySettingsReader(HUEY, HUEYS)
+
+        with self.assertRaises(ConfigurationError):
+            config.configure()
+
+    def test_djhuey_configure_is_redis_huey_when_no_setting_is_defined(self):
+        config = DjangoHueySettingsReader(None, None)
+
+        config.configure()
+
+        self.assertTrue(isinstance(config.huey_setting, RedisHuey))
+        self.assertEquals(config.huey_setting.name, 'test')
+
+
+    def test_djhuey_configure_when_huey_setting_is_defined(self, *args):
+        HUEY = {
+            'huey_class': 'huey.RedisHuey',  # Huey implementation to use.
+            'name': 'testname',  # Use db name for huey.
+        }
+
+        config = DjangoHueySettingsReader(HUEY, None)
+
+        config.configure()
+
+        self.assertTrue(isinstance(config.huey_setting, RedisHuey))
+        self.assertEquals(config.default_queue(None).name, 'testname')
+
+    def test_djhuey_configure_when_hueys_setting_is_defined(self, *args):
+        HUEYS = {
+            'first': {
+                'huey_class': 'huey.RedisHuey',  # Huey implementation to use.
+                'name': 'testname',  # Use db name for huey.
+            },
+            'mails': {
+                'huey_class': 'huey.MemoryHuey',  # Huey implementation to use.
+                'name': 'testnamememory',  # Use db name for huey.
+            }
+        }
+
+        config = DjangoHueySettingsReader(None, HUEYS)
+
+        config.configure()
+
+        self.assertTrue(isinstance(config.default_queue('first'), RedisHuey))
+        self.assertEquals(config.default_queue('first').name, 'testname')
+        self.assertTrue(isinstance(config.default_queue('mails'), MemoryHuey))
+        self.assertEquals(config.default_queue('mails').name, 'testnamememory')
+
+    def test_djhuey_configure_when_hueys_setting_is_defined(self, *args):
+        HUEYS = object()
+
+        config = DjangoHueySettingsReader(None, HUEYS)
+
+        with self.assertRaises(SystemExit):
+            config.configure()
+

--- a/huey/tests/__init__.py
+++ b/huey/tests/__init__.py
@@ -11,3 +11,8 @@ from huey.tests.test_sql_huey import *
 from huey.tests.test_storage import *
 from huey.tests.test_utils import *
 from huey.tests.test_wrappers import *
+
+import os 
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "huey.contrib.djhuey.tests.settings")
+from huey.contrib.djhuey.tests import *


### PR DESCRIPTION
Hi

This pull request provides the ability for djhuey extension to manage multiple queues. A new django setting is added: HUEYS.
The old HUEY configuration is still valid but you can't use both of them, a configuration error is raised.
An example of the HUEYS setting is:

```python
HUEYS = {
    'first': {
        'name': 'my-app',
        'connection': {'host': 'localhost', 'port': 6379},
        'consumer': {
            'workers': 4,
            'worker_type': 'process',  
        }
    },
    'emails': {
        'name': 'email',
        'connection': {'host': 'localhost', 'port': 6379},
        'consumer': {
            'workers': 2,
            'worker_type': 'process',  
        },
    },
}
```

Then, you can use all the huey decorators passing the queue kwarg:
```python
@task(queue='mails')
def some_task(*args, **kwargs):
     # do something
```

Also all the huey functions are available and accept the queue kwarg:
```python
@db_task(queue='mails')
def some_db_task(*args, **kwargs):
     # do something

@db_periodic_task(queue='mails')
def db_periodic_task(*args, **kwargs):
     # do something

# periodic_task, lock_task, enqueue, restore, restore_all, restore_by_id, revoke, revoke_all
# revoke_by_id, is_revoked, result, scheduled, on_startup, on_shutdown, pre_execute, 
# post_execute, signal, disconnect_signal
```

I know that documentation is not updated and some options, such as setting a default queue, could be added but I want you to review the current progress and let me know if it worth to be included.

Let me know your opinion,
Regards