### PR TITLE
Ensure `default_queue_name` returns a str

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -48,7 +48,7 @@ def default_queue_name():
         return settings.DATABASE_NAME
     except AttributeError:
         try:
-            return settings.DATABASES['default']['NAME']
+            return str(settings.DATABASES['default']['NAME'])
         except KeyError:
             return 'huey'
 


### PR DESCRIPTION
This PR works around an issue encountered when `settings.DATABASES['default']['NAME']` is a Path object. Without this change this configuration leads to an obscure error when a name is not set explicitly in the Django settings file:

> powbal-app-1  | [2021-10-14 11:47:50,395] ERROR:huey.consumer.Worker:Worker-1:Error reading from queue
> powbal-app-1  | Traceback (most recent call last):
> powbal-app-1  |   File "/usr/local/lib/python3.8/site-packages/huey/consumer.py", line 109, in loop
> powbal-app-1  |     task = self.huey.dequeue()
> powbal-app-1  |   File "/usr/local/lib/python3.8/site-packages/huey/api.py", line 306, in dequeue
> powbal-app-1  |     data = self.storage.dequeue()
> powbal-app-1  |   File "/usr/local/lib/python3.8/site-packages/huey/storage.py", line 735, in dequeue
> powbal-app-1  |     curs.execute('select id, data from task where queue = ? '
> powbal-app-1  | sqlite3.InterfaceError: Error binding parameter 0 - probably unsupported type.
