### PR TITLE
Add --die-on-term option - remap SIGTERM and SIGINT

### DIFF
--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -255,6 +255,10 @@ they are currently executing before the process exits.
 Alternatively, you can shutdown the consumer using ``SIGTERM`` and any running
 tasks will be interrupted, ensuring the process exits quickly.
 
+If you want to reverse the behaviour, use a ``--die-on-term``
+parameter. If you run Huey on Heroku, you want to use this option as
+``SIGTERM`` is used as a graceful shutdown signal.
+
 .. _consumer-restart:
 
 Consumer restart

--- a/huey/consumer_options.py
+++ b/huey/consumer_options.py
@@ -21,6 +21,7 @@ config_defaults = (
     ('verbose', None),
     ('simple_log', None),
     ('flush_locks', False),
+    ('die_on_term', False),
 )
 config_keys = [param for param, _ in config_defaults]
 
@@ -67,6 +68,9 @@ class OptionParserHandler(object):
                          'restarting any worker that crashes unexpectedly.')),
             option('flush_locks', action='store_true', dest='flush_locks',
                    help=('flush all locks when starting consumer.')),
+            option('die_on_term', action='store_true',
+                   help=('Perform graceful shutdown on SIGTERM and immediate '
+                         'shutdown on SIGINT.')),
         )
 
     def get_scheduler_options(self):

--- a/huey/tests/test_consumer.py
+++ b/huey/tests/test_consumer.py
@@ -1,4 +1,5 @@
 import datetime
+import signal
 import time
 
 from huey.api import crontab
@@ -124,6 +125,8 @@ class TestConsumerConfig(BaseTestCase):
         self.assertEqual(consumer.default_delay, 0.1)
         self.assertEqual(consumer.scheduler_interval, 1)
         self.assertTrue(consumer._health_check)
+        self.assertEqual(consumer.graceful_stop_signal, signal.SIGINT)
+        self.assertEqual(consumer.immediate_stop_signal, signal.SIGTERM)
 
     def test_consumer_config(self):
         cfg = ConsumerConfig(workers=3, worker_type='process', initial_delay=1,
@@ -150,3 +153,10 @@ class TestConsumerConfig(BaseTestCase):
         assertInvalid(scheduler_interval=90)
         assertInvalid(scheduler_interval=7)
         assertInvalid(scheduler_interval=45)
+
+    def test_die_on_term_signal_configueration(self):
+        cfg = ConsumerConfig(die_on_term=True)
+        cfg.validate()
+        consumer = self.huey.create_consumer(**cfg.values)
+        self.assertEqual(consumer.graceful_stop_signal, signal.SIGTERM)
+        self.assertEqual(consumer.immediate_stop_signal, signal.SIGINT)


### PR DESCRIPTION
I tried using Huey on Heroku. Sadly there's one obstacle from running it reasonably well - there's a mismatch between [expected signals](https://devcenter.heroku.com/articles/dynos#graceful-shutdown-with-sigterm). In Huey `SIGTERM` is a brutal shutdown where on Heroku `SIGTERM` is used to shut down things gracefully.

I used `--die-on-term` because that's what [uWSGI uses](https://uwsgi-docs.readthedocs.io/en/latest/Management.html?highlight=sigterm#signals-for-controlling-uwsgi). I tried to come up with a better naming but it's extremely hard!

Let me know what I could do to get this functionality into Huey or if there's a better way of remapping signals without adding bloat to this codebase?

## References
- Celery does that with an environment variable `REMAP_SIGTERM=SIGQUIT` - [ref](https://devcenter.heroku.com/articles/celery-heroku#using-remap_sigterm)
- uWSGI uses `die-on-term` option - [ref](https://uwsgi-docs.readthedocs.io/en/latest/Management.html?highlight=sigterm#signals-for-controlling-uwsgi)
- Gunicorn implements the Heroku expected behaviour - [ref](https://docs.gunicorn.org/en/stable/signals.html#master-process)