### PR TITLE
Close django db old connections before executing.

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -127,13 +127,18 @@ disconnect_signal = HUEY.disconnect_signal
 
 def close_db(fn):
     """Decorator to be used with tasks that may operate on the database."""
+
+    def _close_old_connections():
+        if not HUEY.immediate:
+            close_old_connections()
+
     @wraps(fn)
     def inner(*args, **kwargs):
+        _close_old_connections()
         try:
             return fn(*args, **kwargs)
         finally:
-            if not HUEY.immediate:
-                close_old_connections()
+            _close_old_connections()
     return inner
 
 


### PR DESCRIPTION
It seems that django database connections should be closed before task executing. It's the default behaviour of django request lifecycle:

https://github.com/django/django/blob/78163d1ac4407d59bfc5fdf1f84f2dbbb2ed3443/django/db/__init__.py#L41-L42