### PR TITLE
Add type annotation for djhuey.HUEY

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -1,10 +1,14 @@
 from functools import wraps
 from importlib import import_module
+from typing import TYPE_CHECKING
 import sys
 import traceback
 
 from django.conf import settings
 from django.db import close_old_connections
+
+if TYPE_CHECKING:
+    from huey import Huey
 
 
 configuration_message = """
@@ -66,7 +70,7 @@ def config_error(msg):
     sys.exit(1)
 
 
-HUEY = getattr(settings, 'HUEY', None)
+HUEY = getattr(settings, 'HUEY', None)  # type: Huey
 if HUEY is None:
     try:
         RedisHuey = get_backend(default_backend_path)


### PR DESCRIPTION
When using huey's Django integration from PyCharm, unfortunately we don't get intellisense on the top-level methods like `task` or `lock_task` as the dynamic setup of the `HUEY` instance defeats what the type inference can achieve. This means no go-to-implementation, no helpful auto-complete for function arguments, etc. which worsens the developer experience.

This pull request provides a minimally invasive change to fix the issue by declaring the `HUEY` indeed is a `Huey` instance using a type annotation comment which should be supported all the way back to Python 2.7; if there's interest in this initial change, I'm happy submit follow-up pull requests to provide additional type annotation coverage.