### PR TITLE
Add option to specify module name for autoloading tasks w/Django

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -111,7 +111,7 @@ Running the Consumer
 
 To run the consumer, use the ``run_huey`` management command.  This command
 will automatically import any modules in your ``INSTALLED_APPS`` named
-*tasks.py* (or the name specified by the ``--autoload-name option``).  The 
+*tasks.py* (or as specified by the ``--autoload-name`` option).  The 
 consumer can be configured using both the django settings module and/or by 
 specifying options from the command-line.
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -111,8 +111,9 @@ Running the Consumer
 
 To run the consumer, use the ``run_huey`` management command.  This command
 will automatically import any modules in your ``INSTALLED_APPS`` named
-*tasks.py*.  The consumer can be configured using both the django settings
-module and/or by specifying options from the command-line.
+*tasks.py* (or the name specified by the ``--autoload-name option``).  The 
+consumer can be configured using both the django settings module and/or by 
+specifying options from the command-line.
 
 .. note::
     Options specified on the command line take precedence over those specified
@@ -146,6 +147,11 @@ listed here.
 
 ``-A``, ``--disable-autoload``
     Disable automatic loading of tasks modules.
+
+``-i``, ``--autoload-name``
+    Module name to be used for the automatic loading of tasks. The default is 
+    'tasks', but you may prefer to use 'huey_tasks', for example, to avoid
+    conflicts with tasks.py modules in third-party apps.
 
 .. note::
     Due to a conflict with Django's base option list, the "verbose" option is

--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -43,6 +43,11 @@ class Command(BaseCommand):
         parser.add_argument('-A', '--disable-autoload', action='store_true',
                             dest='disable_autoload',
                             help='Do not autoload "tasks.py"')
+        parser.add_argument('-i', '--autoload-name',
+                            dest='autoload_name',
+                            default='tasks',
+                            help='module name to be used for the automatic '
+                                 'loading of tasks (default=tasks)')
 
     def handle(self, *args, **options):
         from huey.contrib.djhuey import HUEY
@@ -74,7 +79,7 @@ class Command(BaseCommand):
                                     consumer_options.pop('huey_verbose', None))
 
         if not options.get('disable_autoload'):
-            autodiscover_modules("tasks")
+            autodiscover_modules(options['autoload_name'])
 
         logger = logging.getLogger('huey')
 


### PR DESCRIPTION
Firstly, thank you for all your work on Huey - it is superb!

This is a simple alternative fix for #362 / #269. The user can opt to use an alternative module name (e.g., huey_tasks.py) to avoid conflicts with third-party apps, rather than having to disable it alltogether.