### PR TITLE
docs: fix simple typo, existant -> existent

### DIFF
--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -203,7 +203,7 @@ class TestRedisExpireStorage(StorageTests, BaseTestCase):
         self.assertEqual(conn.ttl(self.s.result_key(b'k1')), -1)
         self.assertEqual(conn.ttl(self.s.result_key(b'k2')), 3600)
 
-        # Non-existant keys return -2. See redis docs for TTL command.
+        # Non-existent keys return -2. See redis docs for TTL command.
         self.assertEqual(conn.ttl(self.s.result_key(b'k3')), -2)
 
         # Non-expired keys return -1.


### PR DESCRIPTION
There is a small typo in huey/tests/test_storage.py.

Should read `existent` rather than `existant`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md