### PR TITLE
Store original metadata error when exception raised in sub task

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -477,8 +477,13 @@ class Huey(object):
         except AttributeError:  # Seems to only happen on 3.4.
             tb = '- unable to resolve traceback on Python 3.4 -'
 
+        if isinstance(exception, TaskException):
+            error = exception.metadata.get('error') or repr(exception)
+        else:
+            error = repr(exception)
+
         return {
-            'error': repr(exception),
+            'error': error,
             'retries': task.retries,
             'traceback': tb,
             'task_id': task.id,

--- a/huey/tests/test_api.py
+++ b/huey/tests/test_api.py
@@ -578,7 +578,7 @@ class TestQueue(BaseTestCase):
         r = task_o(1)
         self.assertTrue(self.execute_next() is None)
         exc = self.trap_exception(r)
-        self.assertEqual(exc.metadata['error'], 'TaskException()')
+        self.assertEqual(exc.metadata['error'], 'TestError(1)')
 
     def test_retry(self):
         @self.huey.task(retries=1)


### PR DESCRIPTION
If a sub task fails with exception, then parent task loses original error.

```python
@huey.task()
def task1():
    t = task2()
    t.get(blocking=True)

@huey.task()
def task2():
    raise Exception("Test")
```
For now the result's metadata error of the task1 will be `TaskException()`. But, I think, it's better to store original error `Exception("test")`.