### PR TITLE
Add new task argument to store metadata

### DIFF
--- a/huey/registry.py
+++ b/huey/registry.py
@@ -5,7 +5,8 @@ from huey.exceptions import HueyException
 
 Message = namedtuple('Message', ('id', 'name', 'eta', 'retries', 'retry_delay',
                                  'priority', 'args', 'kwargs', 'on_complete',
-                                 'on_error', 'expires', 'expires_resolved'))
+                                 'on_error', 'expires', 'expires_resolved',
+                                 'meta'))
 
 # Automatically set missing parameters to None. This is kind-of a hack, but it
 # allows us to add new parameters while continuing to be able to handle
@@ -78,7 +79,8 @@ class Registry(object):
             on_complete,
             on_error,
             task.expires,
-            task.expires_resolved)
+            task.expires_resolved,
+            task.meta)
 
     def create_task(self, message):
         # Compatibility with Huey 1.11 message format.
@@ -108,7 +110,8 @@ class Registry(object):
             message.expires,
             on_complete,
             on_error,
-            message.expires_resolved)
+            message.expires_resolved,
+            message.meta)
 
     @property
     def periodic_tasks(self):

--- a/huey/tests/test_registry.py
+++ b/huey/tests/test_registry.py
@@ -49,6 +49,7 @@ class TestRegistry(BaseTestCase):
         self.assertTrue(message.on_error is None)
         self.assertTrue(message.expires is None)
         self.assertTrue(message.expires_resolved is None)
+        self.assertTrue(message.meta is None)
 
         task2 = self.registry.create_task(message)
         self.assertEqual(task2.id, task.id)
@@ -60,6 +61,7 @@ class TestRegistry(BaseTestCase):
         self.assertTrue(task2.on_error is None)
         self.assertTrue(task2.expires is None)
         self.assertTrue(task2.expires_resolved is None)
+        self.assertTrue(task2.meta is None)
 
     def test_missing_task(self):
         @self.huey.task()


### PR DESCRIPTION
I [wrote](https://github.com/getsentry/sentry-python/pull/1555) integration for sentry, and want to add tracing between scheduling and task execution events. To do this, I need to pass `trace_id` (generated by sentry-sdk) between them.

The integration wraps some methods transparently for users, so I can put `trace_id` into args or kwargs.
But it's definitely a bad idea for this purpose.
It will be work fine as long as sentry-sdk is enabled, however a user can disable sentry-sdk between scheduling and task execution. Then kwargs will be contain the unwanted param, which can cause errors.

So I want to add the `meta` param into the `Task` and `Message` classes, which will be used to any metadata of a task at runtime.
