### PR TITLE
remove travis-ci badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,6 @@ huey supports:
 
 .. image:: http://i.imgur.com/2EpRs.jpg
 
-.. image:: https://api.travis-ci.org/coleifer/huey.svg?branch=master
-
 At a glance
 -----------
 


### PR DESCRIPTION
because it's broken.

![Capture d’écran 2023-06-06 à 17 05 28](https://github.com/coleifer/huey/assets/439279/d2102e7f-8364-4dca-aeb7-84c780d18b8f)

