### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ huey
 
 huey is:
 
-* a task queue (**2019-04-01**: :ref:`version 2.0 released <changes>`)
-* written in python (2.7+, 3.4+)
+* a task queue
+* written in python (3.8+, altough older versions might still work)
 * clean and simple API
 * redis, sqlite, file-system, or in-memory storage
 * `example code <https://github.com/coleifer/huey/tree/master/examples/>`_.


### PR DESCRIPTION
Every time I land on the huey rtfd page, I get irritated over these rather old statements.

I propose
- to exclude the almost 5 year old "version 2 available now" info
- officially only support python versions that are not EOL yet.