### PR TITLE
Add notes for ConnectionPool size when using greenlet workers

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -183,6 +183,9 @@ patch is to create a custom bootstrap script that mimics the functionality of
         from django.core.management import execute_from_command_line
         execute_from_command_line(sys.argv)
 
+Each greenlet worker requires a connection to Redis. If you're using a
+ConnectionPool, ensure it has enough connections for all workers.
+
 How to create tasks
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -61,6 +61,9 @@ Greenlet workers seem stuck
     to apply the patch inside the ``manage.py`` script. See the Django docs
     section for the code.
 
+    If you're using a ConnectionPool, check that it provides enough connections
+    to cover all Greenlet workers.
+
 Testing projects using Huey
     Use ``immediate=True``:
 


### PR DESCRIPTION
I'm running greenlet workers using djhuey. I used a ConnectionPool and 60 workers from the examples in the documentation, but the worker would spin at 100% CPU usage with no other warnings or failures.

Digging through issues I found https://github.com/coleifer/huey/issues/378#issuecomment-445663015 which mentioned that each greenlet worker gets one connection. I tried to increase the ConnectionPool size and everything worked fine.

I think adding a hint to the documentation that the ConnectionPool should provide enough connections for all greenlet workers would be helpful in case anyone else experiences the same behaviour.