### PR TITLE
Use FOR UPDATE SKIP LOCKED in SqlStorage

### DIFF
--- a/huey/contrib/sql_huey.py
+++ b/huey/contrib/sql_huey.py
@@ -97,7 +97,7 @@ class SqlStorage(BaseStorage):
                  .order_by(self.Task.priority.desc(), self.Task.id)
                  .limit(1))
         if self.database.for_update:
-            query = query.for_update()
+            query = query.for_update('FOR UPDATE SKIP LOCKED')
 
         with self.database.atomic():
             try:
@@ -132,7 +132,7 @@ class SqlStorage(BaseStorage):
                  .where(self.Schedule.timestamp <= timestamp)
                  .tuples())
         if self.database.for_update:
-            query = query.for_update()
+            query = query.for_update('FOR UPDATE SKIP LOCKED')
 
         with self.database.atomic():
             results = list(query)
@@ -186,7 +186,7 @@ class SqlStorage(BaseStorage):
         self.check_conn()
         query = self.kv().where(self.KV.key == key)
         if self.database.for_update:
-            query = query.for_update()
+            query = query.for_update('FOR UPDATE SKIP LOCKED')
 
         with self.database.atomic():
             try:


### PR DESCRIPTION
`huey.contrib.sql_huey.SqlStorage` uses `query.for_update()` to read tasks, which becomes a `SELECT ... FOR UPDATE`. 

However, a `SELECT ... FOR UPDATE SKIP LOCKED` should be used instead:

Multiple workers should be able to handing tasks out concurrently, but in practice, a `FOR UPDATE` causes that all but one worker are waiting on a row lock so all workers take turns getting tasks, only one of them actually working in a task.

Using `FOR UPDATE SKIP LOCKED` solves that problem and allow all workers to actually run concurrently . See: https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/

Both PostgreSQL and MySQL currently supports `SKIP LOCKED`.