### PR TITLE
optionally propagate contextvars through to huey task

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import os
 import signal

--- a/huey/consumer_options.py
+++ b/huey/consumer_options.py
@@ -1,7 +1,6 @@
 import logging
 import optparse
 from collections import namedtuple
-from logging import FileHandler
 
 from huey.constants import WORKER_THREAD
 from huey.constants import WORKER_TYPES

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -1,10 +1,7 @@
-from collections import deque
-import base64
 import contextlib
 import hashlib
 import heapq
 import itertools
-import json
 import os
 import re
 import shutil
@@ -15,7 +12,6 @@ except ImportError:
 import struct
 import threading
 import time
-import warnings
 
 try:
     from redis import ConnectionPool

--- a/huey/utils.py
+++ b/huey/utils.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 import calendar
 import datetime
-import errno
 import os
 import sys
 import time


### PR DESCRIPTION
I use contextvars to track a number of things (active API requests, users, etc) - I'd love to be able to propagate them to my huey tasks. This PR adds a small "wrapper" around task submission and execution that serializes & attaches contextvars to a task if propagate_contextvars is set to True (& then deserializes them & sets them before executing the task in the worker).

I expect you'll want some changes, curious if you'd be open to something like this being merged into huey?