### PR TITLE
Restore documentation for preserve parameter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1310,13 +1310,13 @@ Result
         :raises: ResultTimeout if blocking and timeout specified without result
             becoming ready yet.
 
-        Attempt to retrieve the return value of a task.  By default,
+        Attempts to retrieve the return value of a task. By default,
         :py:meth:`~Result.get` will simply check for the value, returning
-        ``None`` if it is not ready yet. If you want to wait for a value, you
-        can specify ``blocking=True``. This will loop, backing off up to the
+        ``None`` if it is not ready yet. If you want to wait for the result,
+        specify ``blocking=True``. This will loop, backing off up to the
         provided ``max_delay``, until the value is ready or the ``timeout`` is
         reached. If the ``timeout`` is reached before the result is ready, a
-        :py:class:`ResultTimeout` exception will be raised.
+        :py:class:`ResultTimeout` will be raised.
 
         .. warning:: By default the result store will delete a task's return
             value after the value has been successfully read (by a successful

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1303,6 +1303,10 @@ Result
             attempting to fetch result.
         :param bool revoke_on_timeout: if a timeout occurs, revoke the task,
             thereby preventing it from running if it is has not started yet.
+        :param bool preserve: when set to ``True``, this parameter ensures that
+            the task result will be preserved after having been successfully
+            retrieved. Ordinarily, Huey will discard results after they have
+            been read, to prevent the result store from growing without bounds.
         :raises: ResultTimeout if blocking and timeout specified without result
             becoming ready yet.
 
@@ -1313,6 +1317,12 @@ Result
         provided ``max_delay``, until the value is ready or the ``timeout`` is
         reached. If the ``timeout`` is reached before the result is ready, a
         :py:class:`ResultTimeout` exception will be raised.
+
+        .. warning:: By default the result store will delete a task's return
+            value after the value has been successfully read (by a successful
+            call to the :py:meth:`~Huey.result` or :py:meth:`Result.get`
+            methods). If you intend to access the task result multiple times,
+            you must specify ``preserve=True`` when calling these methods.
 
         .. note:: Instead of calling ``.get()``, you can simply call the
             :py:class:`Result` object directly. Both methods accept the same


### PR DESCRIPTION
I was reading https://huey.readthedocs.io/en/latest/api.html#Result.get and was happy to find the `preserve` parameter but could not find further documentation. Maybe it was accidentally removed with e2d9b34f19acf1908f64abfeb54a63aaa739985b ?

In addition to the proposed changes I thought `Hue.result` should only provide the documentation for the id parameter and point to `Result.get` for the other parameters? The documentation of those two methods show some differences, although they should be the same?

```
        :raises: ResultTimeout if blocking and timeout specified without result
            becoming ready yet.
```
is only mentioned on `Result.get`

and 

```
        .. note:: If the task failed with an exception, then a
            :py:class:`TaskException` that wraps the original exception will be
            raised.
```
is only mentioned on `Hue.result`