### PR TITLE
Provide `call_local` for django `on_commit_task`

### DIFF
--- a/huey/contrib/djhuey/__init__.py
+++ b/huey/contrib/djhuey/__init__.py
@@ -185,5 +185,6 @@ def on_commit_task(*args, **kwargs):
                 task_wrapper.huey.enqueue(task)
             transaction.on_commit(enqueue_on_commit)
             return HUEY._result_handle(task)
+        inner.call_local = fn
         return inner
     return decorator


### PR DESCRIPTION
Executes tasks wrapped with on_commit_task, which is pretty convenient in a testing environment.