### PR TITLE
Use more standard arguments for exceptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -528,7 +528,7 @@ Huey object
             @huey.pre_execute()
             def my_pre_execute_hook(task):
                 if datetime.datetime.now().weekday() == 6:
-                    raise CancelExecution('Sunday -- no work will be done.')
+                    raise CancelExecution('Sunday -- no work will be done.', retry=False)
 
     .. py:method:: unregister_pre_execute(name_or_fn)
 
@@ -1287,7 +1287,7 @@ Result
         Traceback (most recent call last):
           File "<stdin>", line 1, in <module>
           File "/home/charles/tmp/huey/src/huey/huey/api.py", line 684, in get
-            raise TaskException(result.metadata)
+            raise TaskException(metadata=result.metadata)
         huey.exceptions.TaskException: Exception('I failed',)
 
     .. py:attribute:: id

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -434,7 +434,7 @@ Example:
         elif something_fatal_is_wrong():
             # Task will NOT be retried, even if it has more than one retry
             # remaining.
-            raise CancelExecution(retry=False)
+            raise CancelExecution('optional message', retry=False)
         elif cancel_and_maybe_retry():
             # Task will only be retried if it has one or more retries
             # remaining (this is the default).

--- a/docs/shared_resources.rst
+++ b/docs/shared_resources.rst
@@ -109,7 +109,7 @@ Example:
         # This pre-execute task will cancel the execution of every task if the
         # current day is Sunday.
         if datetime.datetime.now().weekday() == 6:
-            raise CancelExecution('No tasks on sunday!')
+            raise CancelExecution('No tasks on sunday!', retry=False)
 
     @huey.post_execute()
     def post_execute_hook(task, task_value, exc):

--- a/huey/api.py
+++ b/huey/api.py
@@ -1022,7 +1022,7 @@ class Result(object):
         result = self.get_raw_result(blocking, timeout, backoff, max_delay,
                                      revoke_on_timeout, preserve)
         if result is not None and isinstance(result, Error):
-            raise TaskException(result.metadata)
+            raise TaskException(metadata=result.metadata)
         return result
 
     def is_revoked(self):

--- a/huey/exceptions.py
+++ b/huey/exceptions.py
@@ -4,17 +4,17 @@ class TaskLockedException(HueyException): pass
 class ResultTimeout(HueyException): pass
 
 class CancelExecution(Exception):
-    def __init__(self, retry=None, *args, **kwargs):
+    def __init__(self, *args, retry=None, **kwargs):
         self.retry = retry
         super(CancelExecution, self).__init__(*args, **kwargs)
 class RetryTask(Exception):
-    def __init__(self, msg=None, eta=None, delay=None, *args, **kwargs):
+    def __init__(self, *args, eta=None, delay=None, **kwargs):
         self.eta, self.delay = eta, delay
-        super(RetryTask, self).__init__(msg, *args, **kwargs)
+        super(RetryTask, self).__init__(*args, **kwargs)
 class TaskException(Exception):
-    def __init__(self, metadata=None, *args):
+    def __init__(self, *args, metadata=None, **kwargs):
         self.metadata = metadata or {}
-        super(TaskException, self).__init__(*args)
+        super(TaskException, self).__init__(*args, **kwargs)
 
     def __unicode__(self):
         return self.metadata.get('error') or 'unknown error'

--- a/huey/tests/test_api.py
+++ b/huey/tests/test_api.py
@@ -908,7 +908,7 @@ class TestQueue(BaseTestCase):
     def test_cancel_execution(self):
         @self.huey.task()
         def task_a(n=None):
-            raise CancelExecution(retry=n)
+            raise CancelExecution('some message', retry=n)
 
         r = task_a()
         self.assertTrue(self.execute_next() is None)
@@ -934,7 +934,7 @@ class TestQueue(BaseTestCase):
     def test_cancel_execution_task_retries(self):
         @self.huey.task(retries=2)
         def task_a(n=None):
-            raise CancelExecution(retry=n)
+            raise CancelExecution('some message', retry=n)
 
         # Even though the task itself declares retries, these retries are
         # ignored when cancel is raised with retry=False.


### PR DESCRIPTION
Instead of:

```py
>>> from huey.exceptions import CancelExecution
>>> exc = CancelExecution(False, 'foo bar baz')
```

Use this more standard call, which did not work:
```py
>>> from huey.exceptions import CancelExecution
>>> exc = CancelExecution('foo bar baz', retry=False)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: CancelExecution.__init__() got multiple values for argument 'retry'
```