### PR TITLE
Improve time-based prefixes in `FileStorage`

### DIFF
--- a/huey/storage.py
+++ b/huey/storage.py
@@ -939,7 +939,6 @@ class FileStorage(BaseStorage):
         self._flush_dir(self.queue_path)
 
     def _timestamp_to_prefix(self, ts):
-        # TODO: possibly use ts.timestamp() instead?
         ts = time.mktime(ts.timetuple()) + (ts.microsecond / 1e6)
         return '%012x' % self._partial_secs(ts)
 

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -940,7 +940,7 @@ class FileStorage(BaseStorage):
 
     def _timestamp_to_prefix(self, ts):
         # TODO: possibly use ts.timestamp() instead?
-        ts = time.mktime(ts.timetuple()) + (ts.microsecond / 1e-6)
+        ts = time.mktime(ts.timetuple()) + (ts.microsecond / 1e6)
         return '%012x' % self._partial_secs(ts)
 
     def add_to_schedule(self, data, ts):

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -871,7 +871,7 @@ class FileStorage(BaseStorage):
 
     def _partial_secs(self, fp, multiplier=None):
         if multiplier is None:
-            multiplier = 1e6
+            multiplier = 1000
         return round(multiplier * fp)
 
     def _flush_dir(self, path):


### PR DESCRIPTION
~Because `ts.microsecond` is an integer already, multiplying it then adding to the result of `time.mktime` will be the wrong prefix for that time.~

It was not as mismatched as I first thought, because I completely missed that it was doing multiplication by a negative exponent.

I'm keeping this open because it may still be useful to use a single function for converting from a float with partial seconds to an integer.

```py
>>> (lambda now, mult=1e4: (now * mult, round(now * mult),))(time.time())
(17504291744215.848, 17504291744216)
```