### PR TITLE
Add a decrement_retries parameter to RetryTask

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1469,11 +1469,12 @@ Exceptions
     more retries remaining**. Similarly, if ``retry=True`` then the task will
     be retried regardless.
 
-.. py:class:: RetryTask(msg=None, delay=None, eta=None)
+.. py:class:: RetryTask(msg=None, delay=None, eta=None, decrement_retries=False)
 
     Raised by user code from within a :py:meth:`~Huey.task` function to force a
     retry. When this exception is raised, the task will be retried irrespective
-    of whether it is configured with automatic retries.
+    of whether it is configured with automatic retries, except when
+    ``decrement_retries`` is set to ``True`` and the task has no retries left.
 
     If ``delay`` or ``eta`` is specified, then any ``retry_delay`` set on the
     task will be overridden and the value specified will be used to determine

--- a/huey/api.py
+++ b/huey/api.py
@@ -401,7 +401,8 @@ class Huey(object):
             self._emit(S.SIGNAL_LOCKED, task)
         except RetryTask as exc:
             logger.info('Task %s raised RetryTask, retrying.', task.id)
-            task.retries += 1
+            if not exc.decrement_retries:
+                task.retries += 1
             if exc.eta or exc.delay is not None:
                 retry_eta = normalize_time(exc.eta, exc.delay, self.utc)
             exception = exc

--- a/huey/exceptions.py
+++ b/huey/exceptions.py
@@ -8,8 +8,9 @@ class CancelExecution(Exception):
         self.retry = retry
         super(CancelExecution, self).__init__(*args, **kwargs)
 class RetryTask(Exception):
-    def __init__(self, msg=None, eta=None, delay=None, *args, **kwargs):
+    def __init__(self, msg=None, eta=None, delay=None, *args, decrement_retries=False, **kwargs):
         self.eta, self.delay = eta, delay
+        self.decrement_retries = decrement_retries
         super(RetryTask, self).__init__(msg, *args, **kwargs)
 class TaskException(Exception):
     def __init__(self, metadata=None, *args):


### PR DESCRIPTION
To decrement retries on tasks without having to raise an unhandled exception that will be logged as an error/exception.

This would be useful for tasks with high retries: if you want to retry a task 10 (or 100?) times but might want to have as many `logger.exception()` to check.

In our case, we only send an alert when retries number falls down to 0.