### PR TITLE
metadata for pypi to link to changelog and docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
     author='Charles Leifer',
     author_email='coleifer@gmail.com',
     url='http://github.com/coleifer/huey/',
+    project_urls={
+        'Documentation': 'https://huey.readthedocs.io',
+        'Changelog': 'https://github.com/coleifer/huey/blob/master/CHANGELOG.md',
+    },
     packages=find_packages(),
     extras_require=extras_require,
     package_data={


### PR DESCRIPTION
It took me a while to find the changelog.  With a bit of metadata, I think pypi can link to it directly.

(I know for sure this works with `pyproject.toml`.  But please note I haven't actually tested this with `setup.py`)