### PR TITLE
Fix multiprocessing start method for Windows and Python 3.14+

### DIFF
--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -49,13 +49,17 @@ class Command(BaseCommand):
 
         # Python 3.8+ on MacOS uses an incompatible multiprocess model. In this
         # case we must explicitly configure mp to use fork().
-        if ((sys.version_info >= (3, 8) and sys.platform == 'darwin') or
-            (sys.version_info >= (3, 14))):
-            import multiprocessing
-            try:
+        # Python 3.14+ on Windows fails using the fork method
+        try:
+            if sys.platform == 'win32' or \
+               (sys.platform == 'darwin' and sys.version_info >= (3, 8)) or \
+               sys.version_info >= (3, 14):
+                multiprocessing.set_start_method('spawn', force=True)
+            else:
+                # Unix/Linux or Older Mac systems maintain their beloved fork
                 multiprocessing.set_start_method('fork')
-            except (RuntimeError, ValueError):
-                pass
+        except (RuntimeError, ValueError):
+            pass
 
         consumer_options = {}
         try:

--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-
+import multiprocessing
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.module_loading import autodiscover_modules


### PR DESCRIPTION
the run_huey command crashes on Windows with a ValueError: cannot find context for 'fork'. To address this, I’ve updated run_huey.py to ensure the multiprocessing start method is compatible across different operating systems and Python versions.

Windows does not support the fork method, and Python 3.14 has become stricter, throwing an exception if an unsupported context is requested.

The updated logic ensures the code uses spawn where fork is unsupported or unstable:

Windows: Use spawn to prevent the crash.

macOS (Python 3.8+): Uses spawn to align with Apple's internal framework requirements.

Python 3.14+: Defaults to spawn for forward compatibility.

Linux/Unix: Keeps fork for performance and backward compatibility.

This change should resolve the issue for Windows users while keeping the command reliable on other platforms.