### PR TITLE
Add support for worker_type='process' on Windows

### DIFF
--- a/huey/bin/huey_consumer.py
+++ b/huey/bin/huey_consumer.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+import multiprocessing
 
 from huey.constants import WORKER_PROCESS
 from huey.consumer import Consumer
@@ -41,28 +42,29 @@ def consumer_main():
                if v is not None}
     config = ConsumerConfig(**options)
     config.validate()
-
-    if sys.platform == 'win32' and config.worker_type == WORKER_PROCESS:
-        err('Error:  huey cannot be run in "process"-mode on Windows.')
-        sys.exit(1)
-
     huey_instance = load_huey(args[0])
 
-    # Set up logging for the "huey" namespace.
     logger = logging.getLogger('huey')
     config.setup_logger(logger)
+    os.environ['HUEY_LOGLEVEL'] = str(logger.level)
+    
+    # It is injected into the configuration so that the Consumer passes it on to 
+    # the child processes in Windows ("spawn") and they can rebuild the instance.
+    if args:
+        config.values['huey_import_path'] = args[0]
 
     consumer = huey_instance.create_consumer(**config.values)
     consumer.run()
 
-
 if __name__ == '__main__':
-    # MacOS on 3.8+ and Linux on 3.14+ need to explicitly specify forking.
-    if ((sys.version_info >= (3, 8) and sys.platform == 'darwin') or
-        (sys.version_info >= (3, 14))):
-        import multiprocessing
+    # We explicitly set 'fork' on platforms that support it. 
+    # On Windows, 'fork' is not available so we skip this
+    # entirely — Windows always uses 'spawn' by default.
+    if sys.platform != 'win32':
         try:
-            multiprocessing.set_start_method('fork')
+            if 'fork' in multiprocessing.get_all_start_methods():
+                multiprocessing.set_start_method('fork')
         except (ValueError, RuntimeError):
             pass
+
     consumer_main()

--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -265,6 +265,109 @@ WORKER_TO_ENVIRONMENT = {
     WORKER_PROCESS: ProcessEnvironment,
 }
 
+def _child_sigterm_handler(signum, frame):
+    """
+    Safe handler to kill the child process on Windows/spawn.
+    Avoid using lambdas with empty generators that can freeze the OS (windows).
+    """
+    raise KeyboardInterrupt
+
+def _spawn_child_setup(huey_import_path, worker_type, django_settings_module=None):
+    """
+    Common setup for all child processes under Windows 'spawn'.
+    Re-imports the Django/Huey environment so tasks are registered.
+    Returns the reconstructed huey instance.
+    """
+    import importlib
+
+    huey_logger = logging.getLogger('huey')
+    if not huey_logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('[%(asctime)s] %(levelname)s [PID:%(process)d] %(name)s: %(message)s')
+        handler.setFormatter(formatter)
+        huey_logger.addHandler(handler)
+        log_level = int(os.environ.get('HUEY_LOGLEVEL', logging.INFO))
+        huey_logger.setLevel(log_level)
+
+    # Bootstrap Django settings in the child process.
+    # Under Windows 'spawn', the child starts clean — env vars from the parent
+    # are NOT inherited automatically, so we pass the settings module explicitly.
+    if django_settings_module:
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', django_settings_module)
+        try:
+            import django
+            from django.utils.module_loading import autodiscover_modules
+            
+            django.setup()
+            if os.environ.get('HUEY_DISABLE_AUTOLOAD') != '1':
+                autodiscover_modules('tasks')
+        except ImportError:
+            huey_logger.warning("DJANGO_SETTINGS_MODULE is defined, but Django is not installed.")
+
+    # Now import the huey instance (registry is now populated).
+    # e.g. 'huey.contrib.djhuey.HUEY' -> module='huey.contrib.djhuey', attr='HUEY'
+    module_path, attr = huey_import_path.rsplit('.', 1)
+    module = importlib.import_module(module_path)
+    huey = getattr(module, attr)
+
+    if worker_type == WORKER_PROCESS:
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, _child_sigterm_handler)
+    return huey
+
+
+def _worker_runner(huey_import_path, worker_type, stop_flag,
+                   default_delay, max_delay, backoff, max_tasks,
+                   django_settings_module=None):
+    """
+    Entry point for WORKER child processes under Windows 'spawn'.
+    Receives only picklable primitives. Reconstructs Huey in the child.
+    """
+    huey = _spawn_child_setup(huey_import_path, worker_type,
+                              django_settings_module)
+
+    worker = Worker(huey, default_delay=default_delay, max_delay=max_delay,
+                    backoff=backoff, max_tasks=max_tasks)
+    worker.initialize()
+    try:
+        while not stop_flag.is_set():
+            worker.loop()
+    except KeyboardInterrupt:
+        pass
+    except WorkerRecycle:
+        logging.getLogger('huey.consumer').info('Worker restarting (max tasks).')
+    except Exception:
+        logging.getLogger('huey.consumer').exception('Worker died!')
+    finally:
+        pid = os.getpid()
+        logging.getLogger('huey.consumer').info('Worker process %s - shutdown', pid)
+        worker.shutdown()
+
+
+def _scheduler_runner(huey_import_path, worker_type, stop_flag,
+                      scheduler_interval, periodic,
+                      django_settings_module=None):
+    """
+    Entry point for SCHEDULER child process under Windows 'spawn'.
+    Receives only picklable primitives. Reconstructs Huey in the child.
+    """
+    huey = _spawn_child_setup(huey_import_path, worker_type,
+                              django_settings_module)
+
+    scheduler = Scheduler(huey, interval=scheduler_interval, periodic=periodic)
+    scheduler.initialize()
+    try:
+        while not stop_flag.is_set():
+            scheduler.loop()
+    except KeyboardInterrupt:
+        pass
+    except Exception:
+        logging.getLogger('huey.consumer').exception('Scheduler died!')
+    finally:
+        pid = os.getpid()
+        logging.getLogger('huey.consumer').info('Worker process %s - shutdown', pid)
+        scheduler.shutdown()
+
 
 class Consumer(object):
     """
@@ -280,7 +383,7 @@ class Consumer(object):
                  backoff=1.15, max_delay=10.0, scheduler_interval=1,
                  worker_type=WORKER_THREAD, check_worker_health=True,
                  health_check_interval=10, flush_locks=False,
-                 extra_locks=None, max_tasks=None):
+                 extra_locks=None, max_tasks=None, huey_import_path=None):
 
         self._logger = logging.getLogger('huey.consumer')
         if huey.immediate:
@@ -295,6 +398,7 @@ class Consumer(object):
         self.backoff = backoff  # Exponential backoff factor when queue empty.
         self.max_delay = max_delay  # Maximum interval between polling events.
         self.max_tasks = max_tasks  # Max tasks to execute before recycling.
+        self.huey_import_path = huey_import_path
 
         if max_tasks and not check_worker_health:
             raise ConfigurationError('max_tasks requires check_worker_health '
@@ -383,23 +487,69 @@ class Consumer(object):
         Repeatedly call the `loop()` method of the given process. Unhandled
         exceptions in the `loop()` method will cause the process to terminate.
         """
-        def _run():
-            if self.worker_type == WORKER_PROCESS:
-                self._set_child_signal_handlers()
+        import multiprocessing
+        import sys
 
-            process.initialize()
-            try:
-                while not self.stop_flag.is_set():
-                    process.loop()
-            except KeyboardInterrupt:
-                pass
-            except WorkerRecycle:
-                self._logger.info('Process %s restarting (max tasks).', name)
-            except:
-                self._logger.exception('Process %s died!', name)
-            finally:
-                process.shutdown()
-        return self.environment.create_process(_run, name)
+        ctx_method = multiprocessing.get_start_method(allow_none=True)
+        is_spawn = (ctx_method == 'spawn') or (sys.platform == 'win32')
+
+        if self.worker_type == WORKER_PROCESS and is_spawn:
+            import functools
+            huey_path = getattr(self, 'huey_import_path', None) or getattr(self, '_huey_import_path', None)
+            
+            django_settings = os.environ.get('DJANGO_SETTINGS_MODULE')
+
+            if not huey_path and django_settings:
+                huey_path = 'huey.contrib.djhuey.HUEY'
+
+            if not huey_path:
+                raise ConfigurationError(
+                    'Cannot use worker_type="process" on Windows (or spawn) without '
+                    'providing huey_import_path. Pass the fully-qualified import path '
+                    'to your Huey instance.'
+                )
+
+            if isinstance(process, Scheduler):
+                runnable = functools.partial(
+                    _scheduler_runner,
+                    huey_path,
+                    self.worker_type,
+                    self.stop_flag,
+                    self.scheduler_interval,
+                    self.periodic,
+                    django_settings,
+                )
+            else:
+                runnable = functools.partial(
+                    _worker_runner,
+                    huey_path,
+                    self.worker_type,
+                    self.stop_flag,
+                    self.default_delay,
+                    self.max_delay,
+                    self.backoff,
+                    self.max_tasks,
+                    django_settings,
+                )
+        else:
+            def runnable():
+                if self.worker_type == WORKER_PROCESS and not is_spawn:
+                    self._set_child_signal_handlers()
+
+                process.initialize()
+                try:
+                    while not self.stop_flag.is_set():
+                        process.loop()
+                except KeyboardInterrupt:
+                    pass
+                except WorkerRecycle:
+                    self._logger.info('Process %s restarting (max tasks).', name)
+                except Exception:
+                    self._logger.exception('Process %s died!', name)
+                finally:
+                    process.shutdown()
+                    
+        return self.environment.create_process(runnable, name)
 
     def start(self):
         """
@@ -524,7 +674,8 @@ class Consumer(object):
         restart_occurred = False
         for i, (worker, worker_t) in enumerate(self.worker_threads):
             if not self.environment.is_alive(worker_t):
-                self._logger.warning('Worker %d died, restarting.', i + 1)
+                pid_dead = getattr(worker_t, 'pid', '???')
+                self._logger.warning('Worker %d (PID:%s) died, restarting.', i + 1, pid_dead)
                 worker = self._create_worker()
                 worker_t = self._create_process(worker, 'Worker-%d' % (i + 1))
                 worker_t.start()
@@ -537,7 +688,8 @@ class Consumer(object):
             self._logger.debug('Workers are up and running.')
 
         if not self.environment.is_alive(self.scheduler):
-            self._logger.warning('Scheduler died, restarting.')
+            pid_dead = getattr(self.scheduler, 'pid', '???')
+            self._logger.warning('Scheduler (PID:%s) died, restarting.', pid_dead)
             scheduler = self._create_scheduler()
             self.scheduler = self._create_process(scheduler, 'Scheduler')
             self.scheduler.start()

--- a/huey/contrib/djhuey/management/commands/run_huey.py
+++ b/huey/contrib/djhuey/management/commands/run_huey.py
@@ -1,6 +1,7 @@
 import logging
 import sys
-
+import os
+import multiprocessing
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.module_loading import autodiscover_modules
@@ -47,14 +48,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         from huey.contrib.djhuey import HUEY
 
-        # Python 3.8+ on MacOS uses an incompatible multiprocess model. In this
-        # case we must explicitly configure mp to use fork().
-        if ((sys.version_info >= (3, 8) and sys.platform == 'darwin') or
-            (sys.version_info >= (3, 14))):
-            import multiprocessing
+        # We explicitly set 'fork' on platforms that support it. 
+        # On Windows, 'fork' is not available so we skip this
+        # entirely — Windows always uses 'spawn' by default.
+        if sys.platform != 'win32':
             try:
-                multiprocessing.set_start_method('fork')
-            except (RuntimeError, ValueError):
+                if 'fork' in multiprocessing.get_all_start_methods():
+                    multiprocessing.set_start_method('fork')
+            except RuntimeError:
+                # Context already set elsewhere, ignore.
                 pass
 
         consumer_options = {}
@@ -79,11 +81,28 @@ class Command(BaseCommand):
         config = ConsumerConfig(**consumer_options)
         config.validate()
 
+        if not options.get('disable_autoload'):
+            autodiscover_modules("tasks")
+        else:
+            # We are notifying Windows child processes not to autoload tasks.py. 
+            # This is necessary because the "spawn" start method on Windows causes the child process to re-import the module, 
+            # which would trigger autoloading again. By setting
+            os.environ['HUEY_DISABLE_AUTOLOAD'] = '1'
+
         # Only configure the "huey" logger if it has no handlers. For example,
         # some users may configure the huey logger via the Django global
         # logging config. This prevents duplicating log messages:
         if not logger.handlers:
             config.setup_logger(logger)
 
+        os.environ['HUEY_LOGLEVEL'] = str(logger.level)
+
+        # On Windows, process mode uses 'spawn' and must reconstruct the Huey
+        # instance inside each child process from scratch (nothing complex is
+        # picklable). We tell the consumer where to find HUEY so child
+        # processes can re-import it without pickling.
+        config.values['huey_import_path'] = 'huey.contrib.djhuey.HUEY'
+
         consumer = HUEY.create_consumer(**config.values)
+
         consumer.run()

--- a/huey/storage.py
+++ b/huey/storage.py
@@ -620,12 +620,11 @@ class RedisExpireStorage(RedisStorage):
             self.conn.setex(self.result_key(key), self._expire_time, value)
             if isinstance(key, bytes):
                 key = key.decode('utf8')
-            if self.notify_result:
-                nkey = self.notify_prefix + key
-                pipe = self.conn.pipeline()
-                pipe.lpush(nkey, b'1')
-                pipe.expire(nkey, self.notify_result_ttl)
-                pipe.execute()
+            nkey = self.notify_prefix + key
+            pipe = self.conn.pipeline()
+            pipe.lpush(nkey, b'1')
+            pipe.expire(nkey, self.notify_result_ttl)
+            pipe.execute()
         else:
             self.conn.set(self.result_key(key), value)
 
@@ -743,6 +742,27 @@ class BaseSqlStorage(BaseStorage):
         self._conn = None
         self.initialize_schema()
 
+    def __getstate__(self):
+        """
+        Called by pickle (used by multiprocessing 'spawn' on Windows).
+        We must exclude the live DB connection and the threading.Lock,
+        both of which are not picklable. The child process will recreate
+        them via __setstate__.
+        """
+        state = self.__dict__.copy()
+        state['_conn'] = None          # drop live connection
+        state['lock'] = None           # drop unpicklable Lock
+        return state
+
+    def __setstate__(self, state):
+        """
+        Restore state in the child process. Recreate the lock and let the
+        connection be created lazily on first use.
+        """
+        self.__dict__.update(state)
+        self.lock = threading.Lock()   # fresh lock in child process
+        # _conn stays None; it will be created lazily via the conn property
+
     def close(self):
         if self._conn is None:
             return False
@@ -755,6 +775,20 @@ class BaseSqlStorage(BaseStorage):
     def conn(self):
         if self._conn is None:
             self._conn = self._create_connection()
+            # We secure the schema for databases in memory after unpickling.
+            # We don't use self.initialize_schema() here because it would close the connection.
+            if getattr(self, 'filename', None) == ':memory:':
+                curs = self._conn.cursor()
+                try:
+                    curs.execute(self.begin_sql)
+                    for sql in self.ddl:
+                        curs.execute(sql)
+                    self._conn.commit()
+                except Exception:
+                    self._conn.rollback()
+                    raise
+                finally:
+                    curs.close()
         return self._conn
 
     def _create_connection(self):
@@ -789,6 +823,14 @@ class BaseSqlStorage(BaseStorage):
             curs.execute(query, params or ())
             if results:
                 return curs.fetchall()
+
+
+def _sqlite_binary(b):
+    """
+    Module-level wrapper for sqlite3.Binary so it can be pickled by
+    multiprocessing 'spawn' on Windows. Lambda functions are not picklable.
+    """
+    return sqlite3.Binary(b)
 
 
 class SqliteStorage(BaseSqlStorage):
@@ -834,7 +876,7 @@ class SqliteStorage(BaseSqlStorage):
                 'primary key',
                 'primary key autoincrement')
 
-        self.to_blob = lambda b: sqlite3.Binary(b)
+        self.to_blob = _sqlite_binary  # module-level fn, picklable on Windows
 
         super(SqliteStorage, self).__init__(name)
 


### PR DESCRIPTION
`worker_type='process'` was blocked on Windows because it defaults to the `spawn` multiprocessing start method (since `fork` is unavailable). I've made some adjustments to make the environment and storage classes "picklable", allowing child processes to successfully reconstruct the Huey instance under `spawn`.

* **`consumer.py`**: 
  * Refactored `_create_process` to use module-level runner functions (`_worker_runner`, `_scheduler_runner`) and `functools.partial` instead of nested closures. This ensures the target functions can be pickled and sent to the child process.
  * Added `_spawn_child_setup` to properly re-bootstrap the Huey instance (and Django settings, if applicable) inside the fresh child process.
* **`storage.py`**: 
  * Implemented `__getstate__` and `__setstate__` in `BaseSqlStorage` to drop the active DB connection and `threading.Lock` during serialization, recreating them lazily in the child process. 
  * Replaced an unpicklable `lambda` function in `SqliteStorage` with a standard module-level function (`_sqlite_binary`).
* **`run_huey.py` & `huey_consumer.py`**: 
  * Removed the hard block preventing process-mode on Windows.
  * Passed the new `huey_import_path` config value to the consumer so the child processes know exactly where to import the registry/instance from.
  * Cleaned up the `fork` fallback logic to be a bit more generic for non-Windows platforms.