### PR TITLE
chore: simplify the condition in normalize_time

### DIFF
--- a/huey/utils.py
+++ b/huey/utils.py
@@ -102,7 +102,7 @@ def normalize_expire_time(expires, utc=True):
 
 
 def normalize_time(eta=None, delay=None, utc=True):
-    if not ((delay is None) ^ (eta is None)):
+    if (delay is None) == (eta is None):
         raise ValueError('Specify either an eta (datetime) or delay (seconds)')
     elif delay is not None:
         method = (utc and utcnow or


### PR DESCRIPTION
I'm also wondering if switching from `==` to `and` would be better.