### PR TITLE
fix: replace bare except: with except Exception: in consumer.py

### DIFF
--- a/huey/consumer.py
+++ b/huey/consumer.py
@@ -411,7 +411,7 @@ class Consumer(object):
                 pass
             except WorkerRecycle:
                 self._logger.info('Process %s restarting (max tasks).', name)
-            except:
+            except Exception:
                 self._logger.exception('Process %s died!', name)
             finally:
                 process.shutdown()
@@ -515,7 +515,7 @@ class Consumer(object):
         except KeyboardInterrupt:
             self._logger.info('Received SIGINT')
             self.stop(graceful=True)
-        except:
+        except Exception:
             self._logger.exception('Error in consumer.')
             self.stop()
         else:


### PR DESCRIPTION
## Bug Fix: bare `except:` catches `SystemExit` in consumer.py

### Problem

Two bare `except:` clauses in `consumer.py` catch `BaseException` — including `SystemExit` and `GeneratorExit` — which can prevent normal process termination.

**In `_run()` (worker process loop):**

```python
except KeyboardInterrupt:
    pass
except WorkerRecycle:
    self._logger.info('Process %s restarting (max tasks).', name)
except:  # catches SystemExit!
    self._logger.exception('Process %s died!', name)
```

If `sys.exit()` is called inside a worker, the resulting `SystemExit` is caught here, logged as "Process died!", and swallowed — the process cannot exit normally.

**In `loop()` (main consumer loop):**

```python
except KeyboardInterrupt:
    self._logger.info('Received SIGINT')
    self.stop(graceful=True)
except:  # catches SystemExit!
    self._logger.exception('Error in consumer.')
    self.stop()
```

Same issue — `SystemExit` from `self.stop_flag.wait()` would be caught and logged as an error.

### Fix

Change both bare `except:` to `except Exception:`. This still catches all normal runtime errors while allowing `SystemExit`, `KeyboardInterrupt` (already handled above), and `GeneratorExit` to propagate normally.