### PR TITLE
Fix minor typos in docs and test comments

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1169,7 +1169,7 @@ Huey object
         execute again until :py:meth:`TaskWrapper.restore` is called.
 
         This function can be called multiple times, but each call will
-        supercede any restrictions from the previous revocation.
+        supersede any restrictions from the previous revocation.
 
         .. code-block:: python
 
@@ -2273,7 +2273,7 @@ Huey comes with several built-in storage implementations:
     :param str filename: sqlite database filename.
     :param int cache_mb: sqlite page-cache size in megabytes.
     :param bool fsync: if enabled, all writes to the Sqlite database will be
-        synchonized. This provides greater safety from database corruption in
+        synchronized. This provides greater safety from database corruption in
         the event of sudden power-loss.
     :param str journal_mode: sqlite journaling mode to use. Defaults to using
         write-ahead logging, which enables readers to coexist with a single

--- a/huey/tests/test_storage.py
+++ b/huey/tests/test_storage.py
@@ -291,7 +291,7 @@ class TestRedisExpireStorage(StorageTests, BaseTestCase):
         self.assertEqual(conn.ttl(self.s.result_key(b'k1')), -1)
         self.assertTrue(3580 <= conn.ttl(self.s.result_key(b'k2')) <= 3600)
 
-        # Non-existant keys return -2. See redis docs for TTL command.
+        # Non-existent keys return -2. See redis docs for TTL command.
         self.assertEqual(conn.ttl(self.s.result_key(b'k3')), -2)
 
         # Non-expired keys return -1.


### PR DESCRIPTION
Fix a few typos found by codespell:

- `supercede` -> `supersede` in `docs/api.rst`
- `synchonized` -> `synchronized` in `docs/api.rst`
- `Non-existant` -> `Non-existent` in `huey/tests/test_storage.py`

All changes are in documentation and comments - no logic changed.