### PR TITLE
Store the real traceback in build_error_result

### DIFF
--- a/huey/api.py
+++ b/huey/api.py
@@ -627,7 +627,11 @@ class Huey(object):
                                  'hook %s for %s.', name, task)
 
     def build_error_result(self, task, exception):
-        tb = traceback.format_exc()
+        # Format the exception's own traceback rather than relying on
+        # traceback.format_exc(), which returns 'NoneType: None' here because
+        # this runs outside the except block that handled the exception.
+        tb = ''.join(traceback.format_exception(
+            type(exception), exception, exception.__traceback__))
         if isinstance(exception, TaskException):
             error = exception.metadata.get('error') or repr(exception)
         else:

--- a/huey/tests/test_api.py
+++ b/huey/tests/test_api.py
@@ -792,6 +792,8 @@ class TestQueue(BaseTestCase):
         err = self.trap_exception(re)
         self.assertEqual(err.metadata['error'], 'TestError(uh-oh)')
         self.assertEqual(err.metadata['retries'], 0)
+        self.assertIn('TestError', err.metadata['traceback'])
+        self.assertIn('uh-oh', err.metadata['traceback'])
 
         self.assertEqual(self.huey.result_count(), 0)
         self.assertEqual(len(self.huey), 0)


### PR DESCRIPTION
### Problem

A failed task's error result carries a `traceback` field, but it is always the string `'NoneType: None\n'` instead of the real traceback:

```python
from huey import MemoryHuey
from huey.exceptions import TaskException

huey = MemoryHuey(results=True)

@huey.task()
def boom():
    raise ValueError('kapow')

r = boom()
huey.execute(huey.dequeue())
try:
    r.get()
except TaskException as e:
    print(repr(e.metadata['traceback']))   # "'NoneType: None\n'"
```

`error` and `task_id` are correct — only the traceback is lost. Every failed task is affected.

### Cause

`Huey.build_error_result` fills the field with `traceback.format_exc()`:

```python
def build_error_result(self, task, exception):
    tb = traceback.format_exc()
    ...
```

but it is called from `_execute` *after* the `try/except` that handled the task's exception has already completed. In Python 3, `traceback.format_exc()` reflects the currently-handled exception only while inside the `except` block; once control leaves the handler `sys.exc_info()` is cleared, so it returns `'NoneType: None'`. (The `logger.exception(...)` call logs the real traceback because it runs inside the handler — the stored result does not.)

### Fix

Format the exception's own `__traceback__`, which doesn't depend on being inside a handler:

```python
tb = ''.join(traceback.format_exception(
    type(exception), exception, exception.__traceback__))
```

This is the same approach the Django contrib backend already uses (`huey/contrib/djhuey/tasks_backend.py`).

### Tests

Extended `test_api.py::test_task_error` to assert the stored `metadata['traceback']` contains the error class and message. It fails on `master` (`'NoneType: None\n'`) and passes with the fix.